### PR TITLE
feat: enhance customization options and add house rename

### DIFF
--- a/frontend/src/lib/house.js
+++ b/frontend/src/lib/house.js
@@ -16,15 +16,29 @@ export function clearActiveHouse() {
   localStorage.removeItem(HOUSE_KEY)
 }
 
-export const AVATARS = ['🧑', '👩', '👨', '🧒', '👧', '👦', '🐱', '🐶', '🌿', '🌸', '🏠', '⭐']
+export const AVATARS = [
+  '🧑', '👩', '👨', '🧒', '👧', '👦',
+  '🐱', '🐶', '🐰', '🐻', '🦊', '🐸',
+  '🌿', '🌸', '🌻', '🍀', '🌈', '🔥',
+  '🏠', '⭐', '🌙', '💎', '🎵', '🦋',
+  '🍕', '☕', '🎨', '🚀', '👑', '🎯',
+]
 
 export const COLORS = [
-  '#6a9960',
-  '#b85a3a',
-  '#5b82b8',
-  '#b8a55b',
-  '#8b5bb8',
-  '#b85b8a',
-  '#5bb8a5',
-  '#b87a5b',
+  '#6a9960',  // moss green
+  '#b85a3a',  // clay/rust
+  '#5b82b8',  // blue
+  '#b8a55b',  // gold/olive
+  '#8b5bb8',  // purple
+  '#b85b8a',  // rose
+  '#5bb8a5',  // teal
+  '#b87a5b',  // warm orange
+  '#e07b4c',  // bright orange
+  '#4a8c6f',  // emerald
+  '#c25d7e',  // raspberry
+  '#6b7fb8',  // periwinkle
+  '#9b8a5e',  // khaki
+  '#7b6aa0',  // lavender
+  '#d4915e',  // peach
+  '#5a9ca0',  // ocean
 ]

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -212,7 +212,7 @@ export default function Admin() {
                     background: m.role === 'owner' ? 'rgba(184,90,58,0.1)' : m.role === 'admin' ? 'rgba(91,130,184,0.1)' : 'rgba(106,153,96,0.1)',
                     color: m.role === 'owner' ? 'var(--clay-500)' : m.role === 'admin' ? '#5b82b8' : 'var(--moss-500)',
                   }}>
-                  {m.role === 'owner' ? 'Dueno' : m.role === 'admin' ? 'Admin' : 'Miembro'}
+                  {m.role === 'owner' ? 'Dueño' : m.role === 'admin' ? 'Admin' : 'Miembro'}
                 </span>
               </div>
             ))}

--- a/frontend/src/pages/HouseSelect.jsx
+++ b/frontend/src/pages/HouseSelect.jsx
@@ -144,7 +144,7 @@ export default function HouseSelect() {
                       {inv.organization?.name || 'Casa'}
                     </p>
                     <p className="font-body text-[12px]" style={{ color: 'var(--bark-300)' }}>
-                      Rol: {inv.role === 'owner' ? 'Dueno' : inv.role === 'admin' ? 'Admin' : 'Miembro'}
+                      Rol: {inv.role === 'owner' ? 'Dueño' : inv.role === 'admin' ? 'Admin' : 'Miembro'}
                     </p>
                   </div>
                   <div className="flex gap-2">

--- a/frontend/src/pages/HouseSettings.jsx
+++ b/frontend/src/pages/HouseSettings.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router-dom'
 import { authClient } from '../lib/auth'
-import { getActiveHouse, clearActiveHouse, AVATARS, COLORS } from '../lib/house'
+import { getActiveHouse, setActiveHouse, clearActiveHouse, AVATARS, COLORS } from '../lib/house'
 import { fetchHouseMembers, fetchHouseProfile, updateHouseProfile } from '../lib/api'
 
 export default function HouseSettings() {
@@ -18,6 +18,9 @@ export default function HouseSettings() {
   const [toast, setToast] = useState(null)
   const [showProfileEdit, setShowProfileEdit] = useState(false)
   const [removingId, setRemovingId] = useState(null)
+  const [editingName, setEditingName] = useState(false)
+  const [houseName, setHouseName] = useState(house?.name || '')
+  const [savingName, setSavingName] = useState(false)
   const { data: session } = authClient.useSession()
 
   const showToast = (msg, type = 'success') => {
@@ -107,8 +110,35 @@ export default function HouseSettings() {
     navigate('/houses')
   }
 
+  async function handleRenameSave() {
+    const trimmed = houseName.trim()
+    if (!trimmed || trimmed === house?.name) {
+      setEditingName(false)
+      setHouseName(house?.name || '')
+      return
+    }
+    setSavingName(true)
+    try {
+      const result = await authClient.organization.update({
+        data: { name: trimmed },
+        organizationId: house.id,
+      })
+      if (result.error) {
+        showToast(result.error.message || 'Error al renombrar', 'error')
+      } else {
+        setActiveHouse({ ...house, name: trimmed })
+        showToast('Nombre actualizado')
+      }
+    } catch (err) {
+      showToast(err.message || 'Error al renombrar', 'error')
+    } finally {
+      setSavingName(false)
+      setEditingName(false)
+    }
+  }
+
   const roleLabel = (role) => {
-    if (role === 'owner') return 'Dueno'
+    if (role === 'owner') return 'Dueño'
     if (role === 'admin') return 'Admin'
     return 'Miembro'
   }
@@ -149,9 +179,57 @@ export default function HouseSettings() {
         <p className="font-body text-[11px] font-semibold uppercase tracking-[0.1em] mb-1.5" style={{ color: 'var(--bark-300)' }}>
           Configuracion
         </p>
-        <h2 className="font-display text-[28px] leading-none" style={{ color: 'var(--bark-700)' }}>
-          {house?.name || 'Casa'}
-        </h2>
+        {editingName ? (
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={houseName}
+              onChange={e => setHouseName(e.target.value)}
+              maxLength={50}
+              autoFocus
+              className="font-display text-[28px] leading-none outline-none px-2 py-1 rounded-xl flex-1 min-w-0"
+              style={{ color: 'var(--bark-700)', background: 'var(--surface-elevated)', border: '1.5px solid var(--moss-400)' }}
+              onKeyDown={e => {
+                if (e.key === 'Enter') handleRenameSave()
+                if (e.key === 'Escape') { setEditingName(false); setHouseName(house?.name || '') }
+              }}
+            />
+            <button
+              onClick={handleRenameSave}
+              disabled={savingName}
+              className="px-3 py-1.5 rounded-lg font-body font-semibold text-[12px] text-white transition-all active:scale-95 disabled:opacity-50"
+              style={{ background: 'var(--moss-500)' }}
+            >
+              {savingName ? '...' : 'Guardar'}
+            </button>
+            <button
+              onClick={() => { setEditingName(false); setHouseName(house?.name || '') }}
+              className="px-3 py-1.5 rounded-lg font-body font-semibold text-[12px] transition-all active:scale-95"
+              style={{ color: 'var(--bark-400)' }}
+            >
+              Cancelar
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2">
+            <h2 className="font-display text-[28px] leading-none" style={{ color: 'var(--bark-700)' }}>
+              {houseName || 'Casa'}
+            </h2>
+            {isOwnerOrAdmin && (
+              <button
+                onClick={() => setEditingName(true)}
+                className="p-1.5 rounded-lg transition-all active:scale-90"
+                style={{ color: 'var(--bark-300)' }}
+                title="Renombrar casa"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/>
+                  <path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/>
+                </svg>
+              </button>
+            )}
+          </div>
+        )}
       </div>
 
       {/* My profile section */}


### PR DESCRIPTION
- Add 18 more emoji options for profile avatars (30 total)
- Add 8 more color options for profile customization (16 total)
- Fix typo: 'Dueno' → 'Dueño' in HouseSettings, HouseSelect, Admin
- Add inline house rename functionality for owners/admins

https://claude.ai/code/session_01AjJpy5DUdtPoo8L2LNooXy