### PR TITLE
fix: sync profile avatar in nav after profile update

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -17,6 +17,14 @@ export default function Layout() {
   }, [house?.id])
 
   useEffect(() => {
+    function handleProfileUpdated(e) {
+      setProfile(e.detail)
+    }
+    window.addEventListener('profileUpdated', handleProfileUpdated)
+    return () => window.removeEventListener('profileUpdated', handleProfileUpdated)
+  }, [])
+
+  useEffect(() => {
     function handleClickOutside(e) {
       if (dropdownRef.current && !dropdownRef.current.contains(e.target)) {
         setShowDropdown(false)

--- a/frontend/src/pages/HouseSettings.jsx
+++ b/frontend/src/pages/HouseSettings.jsx
@@ -99,6 +99,7 @@ export default function HouseSettings() {
       const updated = await updateHouseProfile({ avatar, color })
       setMyProfile(updated)
       setShowProfileEdit(false)
+      window.dispatchEvent(new CustomEvent('profileUpdated', { detail: updated }))
       showToast('Perfil actualizado')
     } catch {
       showToast('Error al guardar perfil', 'error')


### PR DESCRIPTION
The Layout avatar only fetched on house change, missing profile edits.
Now HouseSettings dispatches a 'profileUpdated' event that Layout listens
to, so the top-right avatar updates immediately.

https://claude.ai/code/session_01A4rhV6XNuyB3k8ioJnUtC2