### PR TITLE
feat: add shopping list categories for organizing items by store/type

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -38,18 +38,31 @@ CREATE INDEX IF NOT EXISTS idx_products_out_of_stock ON products(is_out_of_stock
 CREATE INDEX IF NOT EXISTS idx_tasks_org ON tasks(organization_id);
 CREATE INDEX IF NOT EXISTS idx_products_org ON products(organization_id);
 
+CREATE TABLE IF NOT EXISTS shopping_categories (
+    id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    name            TEXT NOT NULL,
+    emoji           TEXT NOT NULL DEFAULT '📦',
+    sort_order      INTEGER NOT NULL DEFAULT 0,
+    organization_id TEXT NOT NULL,
+    created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_shopping_categories_org ON shopping_categories(organization_id);
+
 CREATE TABLE IF NOT EXISTS shopping_items (
     id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,
     name        TEXT NOT NULL,
     note        TEXT,
     added_by    TEXT,
     is_purchased BOOLEAN NOT NULL DEFAULT false,
+    category_id UUID REFERENCES shopping_categories(id) ON DELETE SET NULL,
     organization_id TEXT,
     created_at  TIMESTAMPTZ DEFAULT NOW()
 );
 
 CREATE INDEX IF NOT EXISTS idx_shopping_items_purchased ON shopping_items(is_purchased);
 CREATE INDEX IF NOT EXISTS idx_shopping_items_org ON shopping_items(organization_id);
+CREATE INDEX IF NOT EXISTS idx_shopping_items_category ON shopping_items(category_id);
 
 CREATE TABLE IF NOT EXISTS house_member_profiles (
     id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -134,6 +134,24 @@ export async function deleteProduct(id) {
   return request(`/products/${id}`, { method: 'DELETE' })
 }
 
+// --- Shopping Categories ---
+
+export async function fetchShoppingCategories() {
+  return request('/shopping-categories')
+}
+
+export async function createShoppingCategory(category) {
+  return request('/shopping-categories', { method: 'POST', body: JSON.stringify(category) })
+}
+
+export async function updateShoppingCategory(id, updates) {
+  return request(`/shopping-categories/${id}`, { method: 'PATCH', body: JSON.stringify(updates) })
+}
+
+export async function deleteShoppingCategory(id) {
+  return request(`/shopping-categories/${id}`, { method: 'DELETE' })
+}
+
 // --- Shopping List ---
 
 export async function fetchShoppingItems() {

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -6,6 +6,7 @@ import Home from './pages/Home'
 import Admin from './pages/Admin'
 import Products from './pages/Products'
 import ShoppingList from './pages/ShoppingList'
+import ShoppingAdmin from './pages/ShoppingAdmin'
 import Login from './pages/Login'
 import Register from './pages/Register'
 import HouseSelect from './pages/HouseSelect'
@@ -54,6 +55,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/" element={<Home />} />
           <Route path="/products" element={<Products />} />
           <Route path="/shopping" element={<ShoppingList />} />
+          <Route path="/shopping/admin" element={<ShoppingAdmin />} />
           <Route path="/admin" element={<Admin />} />
           <Route path="/house-settings" element={<HouseSettings />} />
         </Route>

--- a/frontend/src/pages/ShoppingAdmin.jsx
+++ b/frontend/src/pages/ShoppingAdmin.jsx
@@ -1,0 +1,312 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  fetchShoppingCategories, createShoppingCategory,
+  updateShoppingCategory, deleteShoppingCategory,
+} from '../lib/api'
+
+const EMOJI_OPTIONS = ['📦', '🏪', '🥩', '🥬', '🧹', '💊', '🍞', '🧀', '🐟', '🍷', '🧴', '🛒', '🏠', '🐾', '👶']
+
+export default function ShoppingAdmin() {
+  const [categories, setCategories] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [newName, setNewName] = useState('')
+  const [newEmoji, setNewEmoji] = useState('📦')
+  const [editingId, setEditingId] = useState(null)
+  const [editName, setEditName] = useState('')
+  const [editEmoji, setEditEmoji] = useState('')
+  const [deletingId, setDeletingId] = useState(null)
+  const [toast, setToast] = useState(null)
+
+  const showToast = (msg, type = 'success') => {
+    setToast({ msg, type })
+    setTimeout(() => setToast(null), 3000)
+  }
+
+  const loadCategories = useCallback(async () => {
+    try {
+      setError(null)
+      const data = await fetchShoppingCategories()
+      setCategories(data)
+    } catch {
+      setError('No se pudieron cargar las categorias.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { loadCategories() }, [loadCategories])
+
+  async function handleAdd(e) {
+    e.preventDefault()
+    if (!newName.trim()) return
+    try {
+      await createShoppingCategory({ name: newName.trim(), emoji: newEmoji })
+      setNewName('')
+      setNewEmoji('📦')
+      showToast('Categoria creada')
+      loadCategories()
+    } catch {
+      showToast('Error al crear', 'error')
+    }
+  }
+
+  async function handleUpdate(cat) {
+    if (!editName.trim()) return
+    try {
+      await updateShoppingCategory(cat.id, { name: editName.trim(), emoji: editEmoji })
+      setEditingId(null)
+      showToast('Categoria actualizada')
+      loadCategories()
+    } catch {
+      showToast('Error al actualizar', 'error')
+    }
+  }
+
+  async function handleDelete(cat) {
+    if (deletingId === cat.id) {
+      try {
+        await deleteShoppingCategory(cat.id)
+        showToast('Categoria eliminada', 'warning')
+        loadCategories()
+      } catch { showToast('Error al eliminar', 'error') }
+      finally { setDeletingId(null) }
+    } else {
+      setDeletingId(cat.id)
+      setTimeout(() => setDeletingId(null), 3000)
+    }
+  }
+
+  function startEdit(cat) {
+    setEditingId(cat.id)
+    setEditName(cat.name)
+    setEditEmoji(cat.emoji)
+  }
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 gap-4 fade-in">
+        <div className="w-10 h-10 rounded-full border-[3px] border-t-transparent animate-spin" style={{ borderColor: 'rgba(184,90,58,0.2)', borderTopColor: 'transparent' }} />
+        <p className="font-body text-sm font-medium" style={{ color: 'var(--bark-300)' }}>Cargando...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="fade-in">
+      {/* Toast */}
+      {toast && (
+        <div
+          className="fixed top-20 left-1/2 z-50 px-4 py-2.5 rounded-xl font-body font-semibold text-[13px] toast-enter"
+          style={{
+            background: toast.type === 'success' ? 'var(--moss-500)' : toast.type === 'warning' ? 'var(--clay-500)' : '#9e4a2e',
+            color: 'white',
+            minWidth: 180,
+            textAlign: 'center',
+            boxShadow: '0 4px 20px rgba(0,0,0,0.15)',
+            transform: 'translateX(-50%)',
+          }}
+        >
+          {toast.msg}
+        </div>
+      )}
+
+      {/* Header */}
+      <div className="mb-6">
+        <Link
+          to="/shopping"
+          className="inline-flex items-center gap-1 font-body text-[12px] font-medium mb-2 transition-all"
+          style={{ color: 'var(--bark-300)' }}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+            <path d="M19 12H5M12 19l-7-7 7-7"/>
+          </svg>
+          Volver a compras
+        </Link>
+        <p className="font-body text-[11px] font-semibold uppercase tracking-[0.1em] mb-1.5" style={{ color: 'var(--bark-300)' }}>
+          Administracion
+        </p>
+        <h2 className="font-display text-[28px] leading-none" style={{ color: 'var(--bark-700)' }}>
+          Categorias de Compras
+        </h2>
+        <p className="font-body text-[13px] mt-2" style={{ color: 'var(--bark-300)' }}>
+          Crea categorias para organizar tu lista de compras por tienda o tipo.
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-xl p-4 mb-4 font-body text-[13px]" style={{ background: 'rgba(184,90,58,0.06)', color: 'var(--clay-500)', border: '1px solid rgba(184,90,58,0.15)' }}>
+          {error}
+        </div>
+      )}
+
+      {/* Add form */}
+      <form onSubmit={handleAdd} className="mb-6">
+        <div className="flex gap-2">
+          <EmojiPicker value={newEmoji} onChange={setNewEmoji} />
+          <input
+            type="text"
+            value={newName}
+            onChange={e => setNewName(e.target.value)}
+            placeholder="Nombre de categoria (ej: Almacen, Carniceria...)"
+            className="flex-1 px-3.5 py-2.5 rounded-xl font-body text-[14px] outline-none transition-all"
+            style={{
+              background: 'var(--surface-card)',
+              border: '1.5px solid rgba(196,184,166,0.3)',
+              color: 'var(--bark-700)',
+            }}
+            onFocus={e => e.target.style.borderColor = 'var(--moss-400)'}
+            onBlur={e => e.target.style.borderColor = 'rgba(196,184,166,0.3)'}
+          />
+          <button
+            type="submit"
+            disabled={!newName.trim()}
+            className="px-4 py-2.5 rounded-xl font-body font-semibold text-[13px] text-white transition-all active:scale-95 disabled:opacity-40"
+            style={{ background: 'var(--moss-500)', boxShadow: '0 2px 8px rgba(77,122,68,0.25)' }}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round">
+              <path d="M12 5v14M5 12h14"/>
+            </svg>
+          </button>
+        </div>
+      </form>
+
+      {/* Categories list */}
+      {categories.length === 0 ? (
+        <div className="text-center py-12 fade-in">
+          <div className="w-14 h-14 mx-auto mb-4 rounded-2xl flex items-center justify-center text-2xl" style={{ background: 'rgba(184,90,58,0.08)' }}>
+            🏷️
+          </div>
+          <p className="font-display text-xl mb-1" style={{ color: 'var(--bark-700)' }}>Sin categorias</p>
+          <p className="font-body text-sm" style={{ color: 'var(--bark-300)' }}>Crea tu primera categoria para organizar las compras</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2 stagger">
+          {categories.map(cat => (
+            <div
+              key={cat.id}
+              className="rounded-xl overflow-hidden task-enter"
+              style={{
+                background: 'var(--surface-card)',
+                border: '1px solid rgba(196,184,166,0.25)',
+                boxShadow: '0 1px 3px rgba(26,22,20,0.04)',
+              }}
+            >
+              {editingId === cat.id ? (
+                <div className="px-3.5 py-3 flex items-center gap-2">
+                  <EmojiPicker value={editEmoji} onChange={setEditEmoji} />
+                  <input
+                    type="text"
+                    value={editName}
+                    onChange={e => setEditName(e.target.value)}
+                    className="flex-1 px-3 py-1.5 rounded-lg font-body text-[14px] outline-none"
+                    style={{
+                      background: 'var(--surface-base)',
+                      border: '1.5px solid var(--moss-400)',
+                      color: 'var(--bark-700)',
+                    }}
+                    autoFocus
+                    onKeyDown={e => {
+                      if (e.key === 'Enter') handleUpdate(cat)
+                      if (e.key === 'Escape') setEditingId(null)
+                    }}
+                  />
+                  <button
+                    onClick={() => handleUpdate(cat)}
+                    className="w-8 h-8 rounded-lg flex items-center justify-center transition-all active:scale-90"
+                    style={{ color: 'var(--moss-500)' }}
+                  >
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M5 13l4 4L19 7"/>
+                    </svg>
+                  </button>
+                  <button
+                    onClick={() => setEditingId(null)}
+                    className="w-8 h-8 rounded-lg flex items-center justify-center transition-all active:scale-90"
+                    style={{ color: 'var(--bark-300)' }}
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                      <path d="M18 6L6 18M6 6l12 12"/>
+                    </svg>
+                  </button>
+                </div>
+              ) : (
+                <div className="flex items-center gap-3 px-3.5 py-3">
+                  <span className="text-xl flex-shrink-0">{cat.emoji}</span>
+                  <span className="flex-1 font-body font-semibold text-[14px]" style={{ color: 'var(--bark-700)' }}>
+                    {cat.name}
+                  </span>
+                  <button
+                    onClick={() => startEdit(cat)}
+                    className="w-8 h-8 rounded-lg flex items-center justify-center transition-all active:scale-90"
+                    style={{ color: 'var(--bark-300)' }}
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
+                      <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/>
+                      <path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/>
+                    </svg>
+                  </button>
+                  <button
+                    onClick={() => handleDelete(cat)}
+                    className="w-8 h-8 rounded-lg flex items-center justify-center transition-all active:scale-90"
+                    style={{
+                      color: deletingId === cat.id ? 'var(--clay-500)' : 'var(--bark-300)',
+                      background: deletingId === cat.id ? 'rgba(184,90,58,0.06)' : 'transparent',
+                    }}
+                  >
+                    {deletingId === cat.id ? (
+                      <span className="font-body font-bold text-[9px]">Seguro?</span>
+                    ) : (
+                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
+                        <path d="M3 6h18M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2"/>
+                      </svg>
+                    )}
+                  </button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function EmojiPicker({ value, onChange }) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="w-11 h-11 rounded-xl flex items-center justify-center text-xl transition-all active:scale-95"
+        style={{
+          background: 'var(--surface-card)',
+          border: '1.5px solid rgba(196,184,166,0.3)',
+        }}
+      >
+        {value}
+      </button>
+      {open && (
+        <div
+          className="absolute top-full left-0 mt-1 p-2 rounded-xl shadow-lg z-20 grid grid-cols-5 gap-1 fade-in"
+          style={{ background: 'var(--surface-card)', border: '1px solid rgba(196,184,166,0.25)', minWidth: 180 }}
+        >
+          {EMOJI_OPTIONS.map(emoji => (
+            <button
+              key={emoji}
+              type="button"
+              onClick={() => { onChange(emoji); setOpen(false) }}
+              className="w-8 h-8 rounded-lg flex items-center justify-center text-lg transition-all hover:scale-110 active:scale-90"
+              style={{ background: value === emoji ? 'rgba(106,153,96,0.15)' : 'transparent' }}
+            >
+              {emoji}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/ShoppingList.jsx
+++ b/frontend/src/pages/ShoppingList.jsx
@@ -1,12 +1,18 @@
 import { useState, useEffect, useCallback } from 'react'
-import { fetchShoppingItems, createShoppingItem, updateShoppingItem, deleteShoppingItem, clearPurchasedItems } from '../lib/api'
+import { Link } from 'react-router-dom'
+import {
+  fetchShoppingItems, createShoppingItem, updateShoppingItem,
+  deleteShoppingItem, clearPurchasedItems, fetchShoppingCategories,
+} from '../lib/api'
 
 export default function ShoppingList() {
   const [items, setItems] = useState([])
+  const [categories, setCategories] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [newName, setNewName] = useState('')
   const [newNote, setNewNote] = useState('')
+  const [newCategoryId, setNewCategoryId] = useState('')
   const [showNote, setShowNote] = useState(false)
   const [deletingId, setDeletingId] = useState(null)
   const [toast, setToast] = useState(null)
@@ -16,11 +22,15 @@ export default function ShoppingList() {
     setTimeout(() => setToast(null), 3000)
   }
 
-  const loadItems = useCallback(async () => {
+  const loadData = useCallback(async () => {
     try {
       setError(null)
-      const data = await fetchShoppingItems()
-      setItems(data)
+      const [itemsData, catsData] = await Promise.all([
+        fetchShoppingItems(),
+        fetchShoppingCategories(),
+      ])
+      setItems(itemsData)
+      setCategories(catsData)
     } catch {
       setError('No se pudo cargar la lista de compras.')
     } finally {
@@ -28,7 +38,7 @@ export default function ShoppingList() {
     }
   }, [])
 
-  useEffect(() => { loadItems() }, [loadItems])
+  useEffect(() => { loadData() }, [loadData])
 
   async function handleAdd(e) {
     e.preventDefault()
@@ -37,12 +47,13 @@ export default function ShoppingList() {
       await createShoppingItem({
         name: newName.trim(),
         note: newNote.trim() || null,
+        category_id: newCategoryId || null,
       })
       setNewName('')
       setNewNote('')
       setShowNote(false)
       showToast('Agregado a la lista')
-      loadItems()
+      loadData()
     } catch {
       showToast('Error al agregar', 'error')
     }
@@ -51,7 +62,7 @@ export default function ShoppingList() {
   async function handleTogglePurchased(item) {
     try {
       await updateShoppingItem(item.id, { is_purchased: !item.is_purchased })
-      loadItems()
+      loadData()
     } catch {
       showToast('Error al actualizar', 'error')
     }
@@ -62,7 +73,7 @@ export default function ShoppingList() {
       try {
         await deleteShoppingItem(item.id)
         showToast('Eliminado', 'warning')
-        loadItems()
+        loadData()
       } catch { showToast('Error al eliminar', 'error') }
       finally { setDeletingId(null) }
     } else {
@@ -75,7 +86,7 @@ export default function ShoppingList() {
     try {
       await clearPurchasedItems()
       showToast('Lista limpiada')
-      loadItems()
+      loadData()
     } catch {
       showToast('Error al limpiar', 'error')
     }
@@ -83,6 +94,9 @@ export default function ShoppingList() {
 
   const pending = items.filter(i => !i.is_purchased)
   const purchased = items.filter(i => i.is_purchased)
+
+  // Group pending items by category
+  const grouped = groupByCategory(pending, categories)
 
   if (loading) {
     return (
@@ -123,6 +137,16 @@ export default function ShoppingList() {
           </h2>
         </div>
         <div className="flex items-center gap-2">
+          <Link
+            to="/shopping/admin"
+            className="w-9 h-9 rounded-xl flex items-center justify-center transition-all active:scale-95"
+            style={{ background: 'rgba(196,184,166,0.15)', color: 'var(--bark-400)' }}
+            title="Administrar categorias"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
+              <circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/>
+            </svg>
+          </Link>
           <div className="px-3 py-1.5 rounded-xl text-center" style={{ background: 'rgba(184,90,58,0.06)', border: '1px solid rgba(184,90,58,0.15)' }}>
             <span className="font-display text-lg leading-none" style={{ color: 'var(--clay-500)' }}>{pending.length}</span>
             <span className="font-body text-[10px] font-semibold uppercase tracking-wider ml-1.5" style={{ color: 'var(--bark-300)' }}>pendientes</span>
@@ -178,25 +202,48 @@ export default function ShoppingList() {
             </svg>
           </button>
         </div>
-        {showNote && (
-          <input
-            type="text"
-            value={newNote}
-            onChange={e => setNewNote(e.target.value)}
-            placeholder="Nota opcional (ej: marca, cantidad...)"
-            className="w-full mt-2 px-3.5 py-2 rounded-xl font-body text-[13px] outline-none transition-all"
-            style={{
-              background: 'var(--surface-card)',
-              border: '1.5px solid rgba(196,184,166,0.3)',
-              color: 'var(--bark-700)',
-            }}
-            onFocus={e => e.target.style.borderColor = 'var(--moss-400)'}
-            onBlur={e => e.target.style.borderColor = 'rgba(196,184,166,0.3)'}
-          />
-        )}
+
+        {/* Category selector + note */}
+        <div className="flex gap-2 mt-2">
+          {categories.length > 0 && (
+            <select
+              value={newCategoryId}
+              onChange={e => setNewCategoryId(e.target.value)}
+              className="px-3 py-2 rounded-xl font-body text-[13px] outline-none transition-all appearance-none cursor-pointer"
+              style={{
+                background: 'var(--surface-card)',
+                border: '1.5px solid rgba(196,184,166,0.3)',
+                color: newCategoryId ? 'var(--bark-700)' : 'var(--bark-300)',
+                minWidth: 0,
+                flex: showNote ? '0 0 auto' : '1',
+              }}
+            >
+              <option value="">Sin categoria</option>
+              {categories.map(cat => (
+                <option key={cat.id} value={cat.id}>{cat.emoji} {cat.name}</option>
+              ))}
+            </select>
+          )}
+          {showNote && (
+            <input
+              type="text"
+              value={newNote}
+              onChange={e => setNewNote(e.target.value)}
+              placeholder="Nota (ej: marca, cantidad...)"
+              className="flex-1 px-3.5 py-2 rounded-xl font-body text-[13px] outline-none transition-all"
+              style={{
+                background: 'var(--surface-card)',
+                border: '1.5px solid rgba(196,184,166,0.3)',
+                color: 'var(--bark-700)',
+              }}
+              onFocus={e => e.target.style.borderColor = 'var(--moss-400)'}
+              onBlur={e => e.target.style.borderColor = 'rgba(196,184,166,0.3)'}
+            />
+          )}
+        </div>
       </form>
 
-      {/* Pending items */}
+      {/* Pending items - grouped by category */}
       {pending.length === 0 && purchased.length === 0 ? (
         <div className="text-center py-12 fade-in">
           <div className="w-14 h-14 mx-auto mb-4 rounded-2xl flex items-center justify-center text-2xl" style={{ background: 'rgba(106,153,96,0.08)' }}>
@@ -208,15 +255,34 @@ export default function ShoppingList() {
       ) : (
         <>
           {pending.length > 0 && (
-            <div className="flex flex-col gap-2 mb-6 stagger">
-              {pending.map(item => (
-                <ShoppingItem
-                  key={item.id}
-                  item={item}
-                  deletingId={deletingId}
-                  onToggle={handleTogglePurchased}
-                  onDelete={handleDelete}
-                />
+            <div className="mb-6">
+              {grouped.map(group => (
+                <div key={group.key} className="mb-4 last:mb-0">
+                  {/* Category header - only show if there are categories in use */}
+                  {(grouped.length > 1 || group.key !== '__none__') && (
+                    <div className="flex items-center gap-2 mb-2 px-1">
+                      <span className="text-sm">{group.emoji}</span>
+                      <span className="font-body text-[12px] font-semibold uppercase tracking-wider" style={{ color: 'var(--bark-400)' }}>
+                        {group.name}
+                      </span>
+                      <span className="font-body text-[11px] font-medium px-1.5 py-0.5 rounded-full" style={{ background: 'rgba(196,184,166,0.15)', color: 'var(--bark-300)' }}>
+                        {group.items.length}
+                      </span>
+                    </div>
+                  )}
+                  <div className="flex flex-col gap-2 stagger">
+                    {group.items.map(item => (
+                      <ShoppingItem
+                        key={item.id}
+                        item={item}
+                        deletingId={deletingId}
+                        onToggle={handleTogglePurchased}
+                        onDelete={handleDelete}
+                        showCategoryBadge={false}
+                      />
+                    ))}
+                  </div>
+                </div>
               ))}
             </div>
           )}
@@ -244,6 +310,7 @@ export default function ShoppingList() {
                     deletingId={deletingId}
                     onToggle={handleTogglePurchased}
                     onDelete={handleDelete}
+                    showCategoryBadge={true}
                   />
                 ))}
               </div>
@@ -255,7 +322,35 @@ export default function ShoppingList() {
   )
 }
 
-function ShoppingItem({ item, deletingId, onToggle, onDelete }) {
+function groupByCategory(items, categories) {
+  const groups = []
+  const catMap = new Map()
+
+  // Group items by category_id
+  for (const item of items) {
+    const key = item.category_id || '__none__'
+    if (!catMap.has(key)) {
+      catMap.set(key, [])
+    }
+    catMap.get(key).push(item)
+  }
+
+  // Build ordered groups: categories first (by sort_order), then uncategorized
+  for (const cat of categories) {
+    if (catMap.has(cat.id)) {
+      groups.push({ key: cat.id, name: cat.name, emoji: cat.emoji, items: catMap.get(cat.id) })
+    }
+  }
+
+  // Uncategorized at the end
+  if (catMap.has('__none__')) {
+    groups.push({ key: '__none__', name: 'Sin categoria', emoji: '📋', items: catMap.get('__none__') })
+  }
+
+  return groups
+}
+
+function ShoppingItem({ item, deletingId, onToggle, onDelete, showCategoryBadge }) {
   const isDeleting = deletingId === item.id
   const timeAgo = formatTimeAgo(item.created_at)
 
@@ -298,10 +393,15 @@ function ShoppingItem({ item, deletingId, onToggle, onDelete }) {
           >
             {item.name}
           </p>
-          <div className="flex items-center gap-2 mt-1">
+          <div className="flex items-center gap-2 mt-1 flex-wrap">
             {item.note && (
               <span className="font-body text-[11px]" style={{ color: 'var(--bark-300)' }}>
                 {item.note}
+              </span>
+            )}
+            {showCategoryBadge && item.category_name && (
+              <span className="font-body text-[10px] font-medium px-1.5 py-0.5 rounded-full" style={{ background: 'rgba(106,153,96,0.1)', color: 'var(--moss-500)' }}>
+                {item.category_emoji} {item.category_name}
               </span>
             )}
             {item.added_by && (

--- a/server/index.js
+++ b/server/index.js
@@ -493,15 +493,86 @@ app.delete('/api/products/:id', requireAuth, requireHouse, async (req, res) => {
   }
 })
 
+// --- Shopping Categories (scoped by house) ---
+
+// GET /api/shopping-categories
+app.get('/api/shopping-categories', requireAuth, requireHouse, async (req, res) => {
+  try {
+    const { rows } = await pool.query(
+      'SELECT * FROM shopping_categories WHERE organization_id = $1 ORDER BY sort_order, name',
+      [req.house.id]
+    )
+    res.json(rows)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// POST /api/shopping-categories
+app.post('/api/shopping-categories', requireAuth, requireHouse, requireRole('owner', 'admin'), async (req, res) => {
+  try {
+    const { name, emoji } = req.body
+    if (!name?.trim()) return res.status(400).json({ error: 'name is required' })
+    // Get next sort_order
+    const { rows: maxRows } = await pool.query(
+      'SELECT COALESCE(MAX(sort_order), -1) + 1 as next_order FROM shopping_categories WHERE organization_id = $1',
+      [req.house.id]
+    )
+    const { rows } = await pool.query(
+      'INSERT INTO shopping_categories (name, emoji, sort_order, organization_id) VALUES ($1, $2, $3, $4) RETURNING *',
+      [name.trim(), emoji || '📦', maxRows[0].next_order, req.house.id]
+    )
+    res.json(rows[0])
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// PATCH /api/shopping-categories/:id
+app.patch('/api/shopping-categories/:id', requireAuth, requireHouse, requireRole('owner', 'admin'), async (req, res) => {
+  try {
+    const { id } = req.params
+    const fields = req.body
+    const keys = Object.keys(fields).filter(k => k !== 'organization_id' && k !== 'id')
+    if (keys.length === 0) return res.status(400).json({ error: 'No fields to update' })
+
+    const setClauses = keys.map((k, i) => `${k} = $${i + 3}`)
+    const values = keys.map(k => fields[k])
+
+    const { rows } = await pool.query(
+      `UPDATE shopping_categories SET ${setClauses.join(', ')} WHERE id = $1 AND organization_id = $2 RETURNING *`,
+      [id, req.house.id, ...values]
+    )
+    if (rows.length === 0) return res.status(404).json({ error: 'Category not found' })
+    res.json(rows[0])
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// DELETE /api/shopping-categories/:id
+app.delete('/api/shopping-categories/:id', requireAuth, requireHouse, requireRole('owner', 'admin'), async (req, res) => {
+  try {
+    const { id } = req.params
+    await pool.query('DELETE FROM shopping_categories WHERE id = $1 AND organization_id = $2', [id, req.house.id])
+    res.json({ ok: true })
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
 // --- Shopping List (scoped by house) ---
 
 // GET /api/shopping-items
 app.get('/api/shopping-items', requireAuth, requireHouse, async (req, res) => {
   try {
-    const { rows } = await pool.query(
-      'SELECT * FROM shopping_items WHERE organization_id = $1 ORDER BY is_purchased, created_at DESC',
-      [req.house.id]
-    )
+    const { rows } = await pool.query(`
+      SELECT si.*, sc.name as category_name, sc.emoji as category_emoji
+      FROM shopping_items si
+      LEFT JOIN shopping_categories sc ON si.category_id = sc.id
+      WHERE si.organization_id = $1
+      ORDER BY si.is_purchased, sc.sort_order NULLS LAST, si.created_at DESC
+    `, [req.house.id])
     res.json(rows)
   } catch (err) {
     res.status(500).json({ error: err.message })
@@ -511,11 +582,11 @@ app.get('/api/shopping-items', requireAuth, requireHouse, async (req, res) => {
 // POST /api/shopping-items
 app.post('/api/shopping-items', requireAuth, requireHouse, async (req, res) => {
   try {
-    const { name, note } = req.body
+    const { name, note, category_id } = req.body
     if (!name?.trim()) return res.status(400).json({ error: 'name is required' })
     const { rows } = await pool.query(
-      'INSERT INTO shopping_items (name, note, added_by, organization_id) VALUES ($1, $2, $3, $4) RETURNING *',
-      [name.trim(), note?.trim() || null, req.user.name || null, req.house.id]
+      'INSERT INTO shopping_items (name, note, added_by, category_id, organization_id) VALUES ($1, $2, $3, $4, $5) RETURNING *',
+      [name.trim(), note?.trim() || null, req.user.name || null, category_id || null, req.house.id]
     )
     res.json(rows[0])
   } catch (err) {
@@ -613,17 +684,31 @@ async function migrate() {
     await pool.query('CREATE INDEX IF NOT EXISTS idx_products_out_of_stock ON products(is_out_of_stock)')
 
     await pool.query(`
+      CREATE TABLE IF NOT EXISTS shopping_categories (
+        id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+        name            TEXT NOT NULL,
+        emoji           TEXT NOT NULL DEFAULT '📦',
+        sort_order      INTEGER NOT NULL DEFAULT 0,
+        organization_id TEXT NOT NULL,
+        created_at      TIMESTAMPTZ DEFAULT NOW()
+      )
+    `)
+    await pool.query('CREATE INDEX IF NOT EXISTS idx_shopping_categories_org ON shopping_categories(organization_id)')
+
+    await pool.query(`
       CREATE TABLE IF NOT EXISTS shopping_items (
         id           UUID DEFAULT gen_random_uuid() PRIMARY KEY,
         name         TEXT NOT NULL,
         note         TEXT,
         added_by     TEXT,
         is_purchased BOOLEAN NOT NULL DEFAULT false,
+        category_id  UUID REFERENCES shopping_categories(id) ON DELETE SET NULL,
         organization_id TEXT,
         created_at   TIMESTAMPTZ DEFAULT NOW()
       )
     `)
     await pool.query('CREATE INDEX IF NOT EXISTS idx_shopping_items_purchased ON shopping_items(is_purchased)')
+    await pool.query('CREATE INDEX IF NOT EXISTS idx_shopping_items_category ON shopping_items(category_id)')
 
     // Migrations for existing installations
 
@@ -643,6 +728,10 @@ async function migrate() {
     await pool.query('CREATE INDEX IF NOT EXISTS idx_tasks_org ON tasks(organization_id)')
     await pool.query('CREATE INDEX IF NOT EXISTS idx_products_org ON products(organization_id)')
     await pool.query('CREATE INDEX IF NOT EXISTS idx_shopping_items_org ON shopping_items(organization_id)')
+
+    // Shopping categories support
+    await addColumnIfMissing('shopping_items', 'category_id', 'UUID REFERENCES shopping_categories(id) ON DELETE SET NULL')
+    await pool.query('CREATE INDEX IF NOT EXISTS idx_shopping_items_category ON shopping_items(category_id)')
 
     // House member profiles table
     await pool.query(`


### PR DESCRIPTION
Users can now create custom categories (e.g., "Almacén", "Carnicería")
from a new Shopping Admin page, and assign them when adding items.
The shopping list groups pending items by category for easier shopping.

- New shopping_categories table with emoji, name, sort_order
- CRUD API endpoints for categories (admin-only create/edit/delete)
- Category selector in the add-item form
- Grouped view by category in the shopping list
- Shopping Admin page accessible via gear icon in shopping list header

https://claude.ai/code/session_01X7pSjSEYtmuFEsptJ2GBmk