### PR TITLE
feat: add super admin dashboard with global app metrics

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -73,3 +73,9 @@ CREATE TABLE IF NOT EXISTS house_member_profiles (
     created_at      TIMESTAMPTZ DEFAULT NOW(),
     UNIQUE(user_id, organization_id)
 );
+
+CREATE TABLE IF NOT EXISTS super_admins (
+    id         UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id    TEXT NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { Outlet, NavLink, useNavigate } from 'react-router-dom'
 import { authClient } from '../lib/auth'
 import { getActiveHouse, clearActiveHouse } from '../lib/house'
-import { fetchHouseProfile } from '../lib/api'
+import { fetchHouseProfile, checkSuperAdmin } from '../lib/api'
 
 export default function Layout() {
   const navigate = useNavigate()
@@ -10,10 +10,12 @@ export default function Layout() {
   const { data: session } = authClient.useSession()
   const [profile, setProfile] = useState(null)
   const [showDropdown, setShowDropdown] = useState(false)
+  const [isSuperAdmin, setIsSuperAdmin] = useState(false)
   const dropdownRef = useRef(null)
 
   useEffect(() => {
     fetchHouseProfile().then(setProfile).catch(() => {})
+    checkSuperAdmin().then(r => setIsSuperAdmin(r.isSuperAdmin)).catch(() => {})
   }, [house?.id])
 
   useEffect(() => {
@@ -141,6 +143,17 @@ export default function Layout() {
                   >
                     Mi perfil
                   </button>
+                  {isSuperAdmin && (
+                    <button
+                      onClick={() => { setShowDropdown(false); navigate('/super-admin') }}
+                      className="w-full px-4 py-2.5 text-left font-body text-[13px] font-medium transition-all hover:opacity-80"
+                      style={{ color: 'var(--moss-600)' }}
+                      onMouseEnter={e => e.currentTarget.style.background = 'rgba(106,153,96,0.06)'}
+                      onMouseLeave={e => e.currentTarget.style.background = 'transparent'}
+                    >
+                      Super Admin
+                    </button>
+                  )}
                   <button
                     onClick={() => { setShowDropdown(false); handleSwitchHouse() }}
                     className="w-full px-4 py-2.5 text-left font-body text-[13px] font-medium transition-all hover:opacity-80"

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -174,6 +174,16 @@ export async function clearPurchasedItems() {
   return request('/shopping-items/clear-purchased', { method: 'DELETE' })
 }
 
+// --- Super Admin ---
+
+export async function checkSuperAdmin() {
+  return request('/super-admin/check')
+}
+
+export async function fetchSuperAdminStats() {
+  return request('/super-admin/stats')
+}
+
 // --- House ---
 
 export async function fetchHouseMembers() {

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -11,6 +11,7 @@ import Login from './pages/Login'
 import Register from './pages/Register'
 import HouseSelect from './pages/HouseSelect'
 import HouseSettings from './pages/HouseSettings'
+import SuperAdmin from './pages/SuperAdmin'
 import Layout from './components/Layout'
 import { authClient } from './lib/auth'
 import { getActiveHouse } from './lib/house'
@@ -49,6 +50,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
 
         {/* Authenticated, no house selected */}
         <Route path="/houses" element={<RequireAuth><HouseSelect /></RequireAuth>} />
+        <Route path="/super-admin" element={<RequireAuth><SuperAdmin /></RequireAuth>} />
 
         {/* Authenticated + house selected */}
         <Route element={<RequireAuth><RequireHouse><Layout /></RequireHouse></RequireAuth>}>

--- a/frontend/src/pages/SuperAdmin.jsx
+++ b/frontend/src/pages/SuperAdmin.jsx
@@ -1,0 +1,173 @@
+import { useState, useEffect } from 'react'
+import { fetchSuperAdminStats } from '../lib/api'
+
+function StatCard({ label, value, color }) {
+  return (
+    <div
+      className="rounded-xl p-4 flex flex-col gap-1"
+      style={{ background: 'var(--surface-card)', border: '1px solid rgba(196,184,166,0.15)' }}
+    >
+      <span className="font-body text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--bark-300)' }}>
+        {label}
+      </span>
+      <span className="font-display text-2xl" style={{ color: color || 'var(--bark-700)' }}>
+        {value}
+      </span>
+    </div>
+  )
+}
+
+function ActivityChart({ data }) {
+  if (!data || data.length === 0) {
+    return (
+      <p className="font-body text-sm" style={{ color: 'var(--bark-300)' }}>
+        Sin actividad en los ultimos 30 dias
+      </p>
+    )
+  }
+
+  const max = Math.max(...data.map(d => d.count), 1)
+
+  return (
+    <div className="flex items-end gap-[3px] h-28">
+      {data.map(d => {
+        const height = Math.max((d.count / max) * 100, 4)
+        const date = new Date(d.day)
+        const label = `${date.getDate()}/${date.getMonth() + 1}`
+        return (
+          <div key={d.day} className="flex-1 flex flex-col items-center gap-1 min-w-0" title={`${label}: ${d.count}`}>
+            <div
+              className="w-full rounded-t-sm transition-all"
+              style={{
+                height: `${height}%`,
+                background: 'var(--moss-500)',
+                opacity: 0.8,
+                minHeight: '3px',
+              }}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default function SuperAdmin() {
+  const [stats, setStats] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    fetchSuperAdminStats()
+      .then(setStats)
+      .catch(err => setError(err.message))
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="w-8 h-8 rounded-full border-[3px] border-t-transparent animate-spin" style={{ borderColor: 'var(--moss-200)', borderTopColor: 'transparent' }} />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl p-6 text-center" style={{ background: 'var(--surface-card)', border: '1px solid rgba(196,184,166,0.15)' }}>
+        <p className="font-body text-sm" style={{ color: 'var(--clay-500)' }}>{error}</p>
+      </div>
+    )
+  }
+
+  if (!stats) return null
+
+  const avgMembers = stats.totalOrganizations > 0
+    ? (stats.totalMembers / stats.totalOrganizations).toFixed(1)
+    : 0
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div>
+        <h2 className="font-display text-xl" style={{ color: 'var(--bark-700)' }}>
+          Panel Super Admin
+        </h2>
+        <p className="font-body text-sm mt-1" style={{ color: 'var(--bark-300)' }}>
+          Vista global de la aplicacion
+        </p>
+      </div>
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-2 gap-3">
+        <StatCard label="Usuarios" value={stats.totalUsers} color="var(--moss-500)" />
+        <StatCard label="Casas" value={stats.totalOrganizations} color="var(--clay-500)" />
+        <StatCard label="Tareas creadas" value={stats.totalTasks} color="var(--bark-700)" />
+        <StatCard label="Completions" value={stats.totalCompletions} color="var(--moss-600)" />
+      </div>
+
+      {/* Derived stat */}
+      <div
+        className="rounded-xl p-4 flex items-center justify-between"
+        style={{ background: 'var(--surface-card)', border: '1px solid rgba(196,184,166,0.15)' }}
+      >
+        <span className="font-body text-sm font-medium" style={{ color: 'var(--bark-300)' }}>
+          Promedio miembros por casa
+        </span>
+        <span className="font-display text-lg" style={{ color: 'var(--clay-500)' }}>
+          {avgMembers}
+        </span>
+      </div>
+
+      {/* Activity chart */}
+      <div
+        className="rounded-xl p-4 flex flex-col gap-3"
+        style={{ background: 'var(--surface-card)', border: '1px solid rgba(196,184,166,0.15)' }}
+      >
+        <h3 className="font-body text-sm font-semibold" style={{ color: 'var(--bark-700)' }}>
+          Actividad ultimos 30 dias
+        </h3>
+        <ActivityChart data={stats.completionsLast30Days} />
+        <p className="font-body text-[11px] text-right" style={{ color: 'var(--bark-300)' }}>
+          Tareas completadas por dia
+        </p>
+      </div>
+
+      {/* Organizations list */}
+      <div className="flex flex-col gap-3">
+        <h3 className="font-body text-sm font-semibold" style={{ color: 'var(--bark-700)' }}>
+          Casas ({stats.organizations.length})
+        </h3>
+        {stats.organizations.map(org => (
+          <div
+            key={org.id}
+            className="rounded-xl p-4 flex flex-col gap-2"
+            style={{ background: 'var(--surface-card)', border: '1px solid rgba(196,184,166,0.15)' }}
+          >
+            <div className="flex items-center justify-between">
+              <span className="font-body text-sm font-semibold" style={{ color: 'var(--bark-700)' }}>
+                {org.name}
+              </span>
+              <span className="font-body text-[11px] px-2 py-0.5 rounded-full" style={{ background: 'var(--moss-100)', color: 'var(--moss-600)' }}>
+                {org.slug}
+              </span>
+            </div>
+            <div className="flex items-center gap-4">
+              <span className="font-body text-xs" style={{ color: 'var(--bark-300)' }}>
+                {org.memberCount} miembro{org.memberCount !== 1 ? 's' : ''}
+              </span>
+              <span className="font-body text-xs" style={{ color: 'var(--bark-300)' }}>
+                {org.taskCount} tarea{org.taskCount !== 1 ? 's' : ''}
+              </span>
+              {org.lastActivity && (
+                <span className="font-body text-xs" style={{ color: 'var(--bark-300)' }}>
+                  Ultima act: {new Date(org.lastActivity).toLocaleDateString('es')}
+                </span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/server/index.js
+++ b/server/index.js
@@ -103,6 +103,87 @@ function requireRole(...roles) {
   }
 }
 
+// --- Super Admin Middleware ---
+
+async function requireSuperAdmin(req, res, next) {
+  try {
+    const { rows } = await pool.query(
+      'SELECT id FROM super_admins WHERE user_id = $1',
+      [req.user.id]
+    )
+    if (rows.length === 0) return res.status(403).json({ error: 'No tienes permisos de super admin' })
+    next()
+  } catch (err) {
+    return res.status(500).json({ error: err.message })
+  }
+}
+
+// GET /api/super-admin/check - check if current user is super admin
+app.get('/api/super-admin/check', requireAuth, async (req, res) => {
+  try {
+    const { rows } = await pool.query(
+      'SELECT id FROM super_admins WHERE user_id = $1',
+      [req.user.id]
+    )
+    res.json({ isSuperAdmin: rows.length > 0 })
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// GET /api/super-admin/stats - global app stats
+app.get('/api/super-admin/stats', requireAuth, requireSuperAdmin, async (req, res) => {
+  try {
+    const [users, orgs, members, tasks, completions, recentCompletions, activeOrgs] = await Promise.all([
+      pool.query('SELECT COUNT(*) as count FROM "user"'),
+      pool.query('SELECT COUNT(*) as count FROM "organization"'),
+      pool.query('SELECT COUNT(*) as count FROM "member"'),
+      pool.query('SELECT COUNT(*) as count FROM tasks'),
+      pool.query('SELECT COUNT(*) as count FROM completions'),
+      pool.query(`
+        SELECT DATE(completed_at) as day, COUNT(*) as count
+        FROM completions
+        WHERE completed_at >= NOW() - INTERVAL '30 days'
+        GROUP BY DATE(completed_at)
+        ORDER BY day
+      `),
+      pool.query(`
+        SELECT o.id, o.name, o.slug, COUNT(DISTINCT m."userId") as member_count,
+               COUNT(DISTINCT t.id) as task_count,
+               MAX(c.completed_at) as last_activity
+        FROM "organization" o
+        LEFT JOIN "member" m ON m."organizationId" = o.id
+        LEFT JOIN tasks t ON t.organization_id = o.id
+        LEFT JOIN completions c ON c.task_id = t.id
+        GROUP BY o.id, o.name, o.slug
+        ORDER BY last_activity DESC NULLS LAST
+      `),
+    ])
+
+    res.json({
+      totalUsers: parseInt(users.rows[0].count),
+      totalOrganizations: parseInt(orgs.rows[0].count),
+      totalMembers: parseInt(members.rows[0].count),
+      totalTasks: parseInt(tasks.rows[0].count),
+      totalCompletions: parseInt(completions.rows[0].count),
+      completionsLast30Days: recentCompletions.rows.map(r => ({
+        day: r.day,
+        count: parseInt(r.count),
+      })),
+      organizations: activeOrgs.rows.map(r => ({
+        id: r.id,
+        name: r.name,
+        slug: r.slug,
+        memberCount: parseInt(r.member_count),
+        taskCount: parseInt(r.task_count),
+        lastActivity: r.last_activity,
+      })),
+    })
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
 // --- House Member Profiles ---
 
 // GET /api/houses/members - list members with profiles
@@ -746,7 +827,15 @@ async function migrate() {
       )
     `)
 
-    // Drop old profiles table is NOT done automatically - keep it for reference
+    // Super admins table
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS super_admins (
+        id         UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+        user_id    TEXT NOT NULL UNIQUE,
+        created_at TIMESTAMPTZ DEFAULT NOW()
+      )
+    `)
+
     console.log('Migrations complete')
   } catch (err) {
     console.error('Migration error:', err.message)


### PR DESCRIPTION
Adds a super_admins table (decoupled from Better Auth), a requireSuperAdmin
middleware, and a /super-admin stats endpoint that returns global metrics
(users, houses, tasks, completions, activity chart). The frontend includes
a new SuperAdmin page accessible from the user dropdown for authorized users.

https://claude.ai/code/session_01VVtnekJDYn7eBM1GwsEJ8Q