### PR TITLE
fix: render SuperAdmin inside Layout to preserve navbar

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -50,7 +50,6 @@ ReactDOM.createRoot(document.getElementById('root')).render(
 
         {/* Authenticated, no house selected */}
         <Route path="/houses" element={<RequireAuth><HouseSelect /></RequireAuth>} />
-        <Route path="/super-admin" element={<RequireAuth><SuperAdmin /></RequireAuth>} />
 
         {/* Authenticated + house selected */}
         <Route element={<RequireAuth><RequireHouse><Layout /></RequireHouse></RequireAuth>}>
@@ -60,6 +59,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/shopping/admin" element={<ShoppingAdmin />} />
           <Route path="/admin" element={<Admin />} />
           <Route path="/house-settings" element={<HouseSettings />} />
+          <Route path="/super-admin" element={<SuperAdmin />} />
         </Route>
 
         {/* Fallback */}


### PR DESCRIPTION
The /super-admin route was outside the Layout wrapper, causing the
navbar, background, and footer to disappear when navigating there.
Moved the route inside the Layout route group so it shares the same
header/nav/footer as all other authenticated pages.

https://claude.ai/code/session_01L4ts2XeNGkcKCcphq1VYqm