### PR TITLE
fix: use flexible substring matching for smart tag category lookup

### DIFF
--- a/frontend/src/lib/smartTags.js
+++ b/frontend/src/lib/smartTags.js
@@ -781,11 +781,12 @@ export function suggestCategory(inputText, categories) {
 
   if (!matchedCategoryName) return null
 
-  // Find matching category in house's categories (by normalized name)
+  // Find matching category in house's categories (flexible substring match)
   const normalizedMatch = normalizeText(matchedCategoryName)
-  const category = categories.find(
-    cat => normalizeText(cat.name) === normalizedMatch
-  )
+  const category = categories.find(cat => {
+    const normalizedCat = normalizeText(cat.name)
+    return normalizedCat.includes(normalizedMatch) || normalizedMatch.includes(normalizedCat)
+  })
 
   return category ? { id: category.id, name: category.name, emoji: category.emoji } : null
 }


### PR DESCRIPTION
Category suggestions were not appearing because the dictionary expected
exact category names (e.g. "Limpieza") but houses may have different
names (e.g. "Productos de limpieza"). Now uses bidirectional includes
so partial name matches work correctly.

https://claude.ai/code/session_01DWRNd6LyLBgdbGextFbcRZ