### PR TITLE
feat: permitir eliminar casa desde configuracion

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,6 +55,12 @@
 
 **Objetivo:** Features inteligentes que den valor inmediato y diferencien de una lista simple.
 
+### 2026-04-13 — Borrado de casas
+- **Eliminar casa desde configuración** — Nueva sección "Zona de peligro" en `/house-settings` visible solo para el dueño, con botón dual-click ("Seguro?") para confirmar. Endpoint `DELETE /api/houses/:id` protegido con verificación de rol `owner`, limpia en transacción tareas, productos, lista de compras, categorías, perfiles de miembros, push subscriptions, invitaciones, miembros y la organización.
+
+### 2026-04-13 — Borrado de casas
+- **Eliminar casa desde Configuración** — Nueva sección "Zona de peligro" en `/house-settings`, visible solo para el `owner`. Botón con patrón dual-click ("Seguro? Toca de nuevo para confirmar") consistente con el resto de la app. Backend: endpoint `DELETE /api/houses/:id` en transacción que limpia `tasks`, `products`, `shopping_items`, `shopping_categories`, `house_member_profiles`, `push_subscriptions`, `invitation`, `member` y `organization`. Verificación de rol owner antes de borrar.
+
 ### 2026-04-08 — Smart Tags + Recomendador de Tareas
 - **Smart Tags en lista de compras** — Diccionario de 600+ keywords en español que sugiere categoría automáticamente al escribir un producto. Chip visual que el usuario acepta o descarta. Frontend-only, sin dependencias externas.
 - **Recomendador de tareas en onboarding** — Wizard de 2 pasos al crear casa: elegir tipo de espacio (Apartamento, Casa familiar, Airbnb, Oficina, Personalizado) y seleccionar/deseleccionar tareas individuales con checkboxes antes de crear. Backend actualizado para aceptar lista explícita de tareas.

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -227,3 +227,7 @@ export async function seedHouse(template = 'small', tasks = null) {
   if (tasks) body.tasks = tasks
   return request('/houses/seed', { method: 'POST', body: JSON.stringify(body) })
 }
+
+export async function deleteHouse(houseId) {
+  return request(`/houses/${houseId}`, { method: 'DELETE' })
+}

--- a/frontend/src/pages/HouseSettings.jsx
+++ b/frontend/src/pages/HouseSettings.jsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router-dom'
 import { authClient } from '../lib/auth'
 import { getActiveHouse, setActiveHouse, clearActiveHouse, AVATARS, COLORS } from '../lib/house'
-import { fetchHouseMembers, fetchHouseProfile, updateHouseProfile, fetchVapidKey, subscribePush, unsubscribePush, fetchPushStatus } from '../lib/api'
+import { fetchHouseMembers, fetchHouseProfile, updateHouseProfile, fetchVapidKey, subscribePush, unsubscribePush, fetchPushStatus, deleteHouse } from '../lib/api'
 
 export default function HouseSettings() {
   const navigate = useNavigate()
@@ -24,6 +24,8 @@ export default function HouseSettings() {
   const [pushSupported, setPushSupported] = useState(false)
   const [pushEnabled, setPushEnabled] = useState(false)
   const [pushLoading, setPushLoading] = useState(false)
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const [deletingHouse, setDeletingHouse] = useState(false)
   const { data: session } = authClient.useSession()
 
   const showToast = (msg, type = 'success') => {
@@ -155,6 +157,25 @@ export default function HouseSettings() {
   function handleLeaveHouse() {
     clearActiveHouse()
     navigate('/houses')
+  }
+
+  async function handleDeleteHouse() {
+    if (!confirmingDelete) {
+      setConfirmingDelete(true)
+      setTimeout(() => setConfirmingDelete(false), 3000)
+      return
+    }
+    setDeletingHouse(true)
+    try {
+      await deleteHouse(house.id)
+      clearActiveHouse()
+      navigate('/houses')
+    } catch (err) {
+      showToast(err.message || 'Error al eliminar la casa', 'error')
+      setConfirmingDelete(false)
+    } finally {
+      setDeletingHouse(false)
+    }
   }
 
   async function handleRenameSave() {
@@ -470,6 +491,42 @@ export default function HouseSettings() {
           Cambiar de casa
         </button>
       </div>
+
+      {/* Zona de peligro - solo owner */}
+      {myRole === 'owner' && (
+        <div className="mt-8">
+          <h3 className="font-display text-lg mb-3" style={{ color: 'var(--clay-500)' }}>
+            Zona de peligro
+          </h3>
+          <div
+            className="rounded-xl p-4"
+            style={{ background: 'rgba(184,90,58,0.04)', border: '1px solid rgba(184,90,58,0.2)' }}
+          >
+            <p className="font-body font-semibold text-[13px] mb-1" style={{ color: 'var(--bark-700)' }}>
+              Eliminar esta casa
+            </p>
+            <p className="font-body text-[12px] mb-3" style={{ color: 'var(--bark-300)' }}>
+              Se borraran todas las tareas, productos, lista de compras y miembros. Esta accion es permanente.
+            </p>
+            <button
+              onClick={handleDeleteHouse}
+              disabled={deletingHouse}
+              className="w-full py-2.5 rounded-xl font-body font-semibold text-[13px] transition-all active:scale-[0.98] disabled:opacity-60"
+              style={{
+                color: confirmingDelete ? 'white' : 'var(--clay-500)',
+                background: confirmingDelete ? 'var(--clay-500)' : 'rgba(184,90,58,0.08)',
+                border: '1.5px solid rgba(184,90,58,0.3)',
+              }}
+            >
+              {deletingHouse
+                ? 'Eliminando...'
+                : confirmingDelete
+                  ? 'Seguro? Toca de nuevo para confirmar'
+                  : 'Eliminar casa'}
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Profile edit modal */}
       {showProfileEdit && (

--- a/server/index.js
+++ b/server/index.js
@@ -242,6 +242,48 @@ app.put('/api/houses/profile', requireAuth, requireHouse, async (req, res) => {
   }
 })
 
+// DELETE /api/houses/:id - delete a house and all its data (owner only)
+app.delete('/api/houses/:id', requireAuth, async (req, res) => {
+  const houseId = req.params.id
+  if (!houseId) return res.status(400).json({ error: 'Casa no especificada' })
+
+  const client = await pool.connect()
+  try {
+    // Verify caller is owner of this house
+    const { rows } = await client.query(
+      'SELECT role FROM "member" WHERE "userId" = $1 AND "organizationId" = $2',
+      [req.user.id, houseId]
+    )
+    if (rows.length === 0) {
+      return res.status(403).json({ error: 'No eres miembro de esta casa' })
+    }
+    if (rows[0].role !== 'owner') {
+      return res.status(403).json({ error: 'Solo el dueno puede eliminar la casa' })
+    }
+
+    await client.query('BEGIN')
+    // Custom tables (organization_id has no FK, so clean explicitly)
+    await client.query('DELETE FROM tasks WHERE organization_id = $1', [houseId])
+    await client.query('DELETE FROM products WHERE organization_id = $1', [houseId])
+    await client.query('DELETE FROM shopping_items WHERE organization_id = $1', [houseId])
+    await client.query('DELETE FROM shopping_categories WHERE organization_id = $1', [houseId])
+    await client.query('DELETE FROM house_member_profiles WHERE organization_id = $1', [houseId])
+    await client.query('DELETE FROM push_subscriptions WHERE organization_id = $1', [houseId])
+    // Better-auth tables
+    await client.query('DELETE FROM "invitation" WHERE "organizationId" = $1', [houseId])
+    await client.query('DELETE FROM "member" WHERE "organizationId" = $1', [houseId])
+    await client.query('DELETE FROM "organization" WHERE id = $1', [houseId])
+    await client.query('COMMIT')
+
+    res.json({ ok: true })
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {})
+    res.status(500).json({ error: err.message })
+  } finally {
+    client.release()
+  }
+})
+
 // POST /api/houses/seed - insert example tasks and products for a new house
 app.post('/api/houses/seed', requireAuth, requireHouse, requireRole('owner', 'admin'), async (req, res) => {
   try {


### PR DESCRIPTION
Añade sección "Zona de peligro" en /house-settings visible solo para el
owner, con botón dual-click ("Seguro?") que confirma y elimina la casa.

Backend: endpoint DELETE /api/houses/:id en transacción que verifica
rol owner y limpia tasks, products, shopping_items, shopping_categories,
house_member_profiles, push_subscriptions, invitation, member y
organization.

https://claude.ai/code/session_01RfabNaSpQRRNfFexQHTXZ9