### PR TITLE
Include lib directory in Docker image build

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /app
 COPY package.json ./
 RUN npm install --production
 COPY index.js auth.js ./
+COPY lib ./lib
 RUN mkdir -p /app/uploads
 EXPOSE 3001
 CMD ["node", "index.js"]


### PR DESCRIPTION
## Summary
Updated the Dockerfile to include the `lib` directory in the Docker image, ensuring all application dependencies are properly copied during the build process.

## Key Changes
- Added `COPY lib ./lib` instruction to the Dockerfile to copy the lib directory into the container

## Implementation Details
The lib directory is now copied after the main application files (index.js and auth.js) but before the uploads directory is created. This ensures that any modules or utilities in the lib directory are available when the application runs in the container.

https://claude.ai/code/session_011ihBZPprs8iSye8a7ettZx