### PR TITLE
Preserve task completion history when resetting tasks

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -8,8 +8,11 @@ CREATE TABLE IF NOT EXISTS tasks (
     product_name  TEXT,
     product_image TEXT,
     organization_id TEXT,
+    last_reset_at TIMESTAMPTZ,
     created_at  TIMESTAMPTZ DEFAULT NOW()
 );
+
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS last_reset_at TIMESTAMPTZ;
 
 CREATE TABLE IF NOT EXISTS completions (
     id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,6 +55,11 @@
 
 **Objetivo:** Features inteligentes que den valor inmediato y diferencien de una lista simple.
 
+### 2026-04-18 — Fix: Resetear tarea ya no borra el historial
+- **Bug:** El botón "Resetear" en Administración borraba todos los registros de `completions` de la tarea para hacerla reaparecer (dependía de `last_completed_at IS NULL`). Resultado: se perdía el historial completo de quién hizo la tarea y cuándo.
+- **Fix:** Nueva columna `tasks.last_reset_at TIMESTAMPTZ`. El endpoint ahora es `POST /api/tasks/:id/reset` (antes `DELETE /api/completions?task_id=...`) y sólo actualiza `last_reset_at = NOW()`. La query `/api/tasks/pending` incluye la tarea cuando `last_reset_at > last_completed_at`, preservando intacto el historial de completions.
+- **Migración automática:** `addColumnIfMissing('tasks', 'last_reset_at', 'TIMESTAMPTZ')` en el arranque del servidor para instalaciones existentes.
+
 ### 2026-04-13 — DevEx: pre-commit hook + CI de tests y coverage
 - **CI `ci.yml` agregado** — Workflow que corre en cada PR y push a `main`: instala dependencias (`frontend`, `server`, root), ejecuta `npm test` (ambos proyectos), `npm run build` (frontend) y `npm run test:coverage` con thresholds. Previamente solo existía `build-and-push.yml` que construía Docker sin validar nada.
 - **Pre-commit hook (Husky)** — `.husky/pre-commit` corre `npm test` + `npm run build` antes de cada commit para cortar temprano lo que rompería CI.

--- a/frontend/src/lib/__tests__/api.test.js
+++ b/frontend/src/lib/__tests__/api.test.js
@@ -83,7 +83,7 @@ describe('api.js — wrappers de tareas/completions', () => {
     ['updateTask', ['id1', { name: 'y' }], 'PATCH', '/tasks/id1', { name: 'y' }],
     ['deleteTask', ['id1'], 'DELETE', '/tasks/id1'],
     ['fetchCompletions', [], 'GET', '/completions'],
-    ['resetTask', ['id1'], 'DELETE', '/completions?task_id=id1'],
+    ['resetTask', ['id1'], 'POST', '/tasks/id1/reset'],
     ['fetchTaskHistory', ['id1', 5], 'GET', '/completions/id1/history?limit=5'],
     ['fetchTaskHistory', ['id1'], 'GET', '/completions/id1/history?limit=10'],
   ]

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -68,7 +68,7 @@ export async function completeTask(taskId) {
 }
 
 export async function resetTask(taskId) {
-  return request(`/completions?task_id=${taskId}`, { method: 'DELETE' })
+  return request(`/tasks/${taskId}/reset`, { method: 'POST' })
 }
 
 export async function fetchTaskHistory(taskId, limit = 10) {

--- a/server/index.js
+++ b/server/index.js
@@ -431,6 +431,7 @@ app.get('/api/tasks/pending', requireAuth, requireHouse, async (req, res) => {
         AND (
           c.last_completed_at IS NULL
           OR NOW() >= c.last_completed_at + (t.frequency_value * INTERVAL '1 day')
+          OR (t.last_reset_at IS NOT NULL AND t.last_reset_at > c.last_completed_at)
         )
       ORDER BY t.name
     `, [req.house.id])
@@ -559,19 +560,17 @@ app.post('/api/completions', requireAuth, requireHouse, async (req, res) => {
   }
 })
 
-// DELETE /api/completions?task_id=xxx
-app.delete('/api/completions', requireAuth, requireHouse, requireRole('owner', 'admin'), async (req, res) => {
+// POST /api/tasks/:id/reset
+// Marca la tarea como pendiente sin borrar historial de completions.
+app.post('/api/tasks/:id/reset', requireAuth, requireHouse, requireRole('owner', 'admin'), async (req, res) => {
   try {
-    const { task_id } = req.query
-    if (!task_id) return res.status(400).json({ error: 'task_id required' })
-    // Verify task belongs to house
-    const { rows: taskCheck } = await pool.query(
-      'SELECT id FROM tasks WHERE id = $1 AND organization_id = $2', [task_id, req.house.id]
+    const { id } = req.params
+    const { rows } = await pool.query(
+      'UPDATE tasks SET last_reset_at = NOW() WHERE id = $1 AND organization_id = $2 RETURNING *',
+      [id, req.house.id]
     )
-    if (taskCheck.length === 0) return res.status(404).json({ error: 'Tarea no encontrada' })
-
-    await pool.query('DELETE FROM completions WHERE task_id = $1', [task_id])
-    res.json({ ok: true })
+    if (rows.length === 0) return res.status(404).json({ error: 'Tarea no encontrada' })
+    res.json(rows[0])
   } catch (err) {
     res.status(500).json({ error: err.message })
   }
@@ -1083,6 +1082,8 @@ async function migrate() {
     await addColumnIfMissing('tasks', 'product_name', 'TEXT')
     // Add product_image to tasks if missing
     await addColumnIfMissing('tasks', 'product_image', 'TEXT')
+    // Reset de aparición sin borrar historial
+    await addColumnIfMissing('tasks', 'last_reset_at', 'TIMESTAMPTZ')
 
     // Multi-tenant columns
     await addColumnIfMissing('tasks', 'organization_id', 'TEXT')


### PR DESCRIPTION
## Summary
Changed the task reset functionality to preserve completion history instead of deleting it. Previously, resetting a task would delete all completion records, losing the audit trail of who completed the task and when. Now, resetting only marks the task as pending again without touching historical data.

## Key Changes

- **New database column**: Added `last_reset_at` (TIMESTAMPTZ) to the `tasks` table to track when a task was last reset
- **API endpoint change**: Replaced `DELETE /api/completions?task_id=xxx` with `POST /api/tasks/:id/reset`
  - Old behavior: Deleted all completion records for the task
  - New behavior: Updates `last_reset_at = NOW()` and returns the updated task
- **Pending tasks query logic**: Updated `/api/tasks/pending` to include tasks where `last_reset_at > last_completed_at`, ensuring reset tasks reappear in the pending list
- **Automatic migration**: Added `addColumnIfMissing()` call in server startup to create the new column for existing installations
- **Frontend API wrapper**: Updated `resetTask()` function to use the new POST endpoint
- **Tests**: Updated test expectations to reflect the new HTTP method and endpoint

## Implementation Details

The fix uses a timestamp-based approach rather than deletion:
1. When a task is reset, `last_reset_at` is set to the current time
2. The pending tasks query checks if `last_reset_at > last_completed_at` to determine if a task should reappear
3. All completion records remain intact for historical reporting and audit purposes
4. The database migration is non-breaking and runs automatically on server startup

https://claude.ai/code/session_01BGCJkwMXuoyQnATqohDvmE