### PR TITLE
feat(products): unidades por compra + aviso de consumo acelerado

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -31,7 +31,9 @@ CREATE TABLE IF NOT EXISTS products (
     category        TEXT NOT NULL DEFAULT 'general',
     is_out_of_stock BOOLEAN NOT NULL DEFAULT false,
     reminder_frequency_days INTEGER NOT NULL DEFAULT 30,
+    units           INTEGER NOT NULL DEFAULT 1,
     last_purchased_at TIMESTAMPTZ,
+    last_out_of_stock_at TIMESTAMPTZ,
     organization_id TEXT,
     created_at      TIMESTAMPTZ DEFAULT NOW()
 );

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,6 +55,12 @@
 
 **Objetivo:** Features inteligentes que den valor inmediato y diferencien de una lista simple.
 
+### 2026-04-23 — Unidades por compra + detección de consumo acelerado
+- **Unidades por compra** — Nueva columna `products.units INTEGER NOT NULL DEFAULT 1` para registrar cuántas unidades se compran por vez (ej: 4 rollos, 2 frascos). Campo en el formulario de producto y badge visible en el card cuando `units > 1`.
+- **Detección de "agotado antes de tiempo"** — Nueva columna `products.last_out_of_stock_at TIMESTAMPTZ`. El endpoint `PATCH /api/products/:id` ahora sincroniza automáticamente este timestamp cuando se cambia `is_out_of_stock`; `POST /api/products/:id/purchase` lo limpia al comprar.
+- **Modal inteligente** — Al marcar un producto como agotado, si la duración real fue menor al 60% de la frecuencia configurada (`EARLY_OUT_OF_STOCK_RATIO = 0.6`), se abre un modal que ofrece dos ajustes: actualizar unidades o actualizar frecuencia (pre-llenada con la duración real observada). Tercera opción "Solo agotarlo" para descartar. No se guarda historial acumulado — sólo se detecta el caso inmediato comparando `last_purchased_at` vs ahora.
+- **Migraciones automáticas:** `addColumnIfMissing('products', 'units', ...)` y `addColumnIfMissing('products', 'last_out_of_stock_at', ...)` en el arranque del servidor.
+
 ### 2026-04-18 — Fix: Resetear tarea ya no borra el historial
 - **Bug:** El botón "Resetear" en Administración borraba todos los registros de `completions` de la tarea para hacerla reaparecer (dependía de `last_completed_at IS NULL`). Resultado: se perdía el historial completo de quién hizo la tarea y cuándo.
 - **Fix:** Nueva columna `tasks.last_reset_at TIMESTAMPTZ`. El endpoint ahora es `POST /api/tasks/:id/reset` (antes `DELETE /api/completions?task_id=...`) y sólo actualiza `last_reset_at = NOW()`. La query `/api/tasks/pending` incluye la tarea cuando `last_reset_at > last_completed_at`, preservando intacto el historial de completions.

--- a/frontend/src/pages/Products.jsx
+++ b/frontend/src/pages/Products.jsx
@@ -4,6 +4,10 @@ import {
   fetchProducts, createProduct, updateProduct, deleteProduct, purchaseProduct,
 } from '../lib/api'
 
+// Si al marcar agotado el producto duró menos de este porcentaje de su frecuencia
+// configurada, abrimos el modal de ajuste. Subir = mas sensible, bajar = mas laxo.
+const EARLY_OUT_OF_STOCK_RATIO = 0.6
+
 const CATEGORIES = [
   { value: 'all', label: 'Todos' },
   { value: 'limpieza', label: 'Limpieza' },
@@ -61,6 +65,7 @@ export default function Products() {
   const [editingProduct, setEditingProduct] = useState(null)
   const [deletingId, setDeletingId] = useState(null)
   const [toast, setToast] = useState(null)
+  const [earlyOutModal, setEarlyOutModal] = useState(null)
 
   const showToast = (msg, type = 'success') => {
     setToast({ msg, type })
@@ -114,9 +119,39 @@ export default function Products() {
 
   async function handleToggleOutOfStock(product) {
     try {
-      await updateProduct(product.id, { is_out_of_stock: !product.is_out_of_stock })
+      const next = !product.is_out_of_stock
+      const updated = await updateProduct(product.id, { is_out_of_stock: next })
       loadProducts()
-      showToast(product.is_out_of_stock ? 'Producto disponible' : 'Marcado como agotado', product.is_out_of_stock ? 'success' : 'warning')
+      showToast(next ? 'Marcado como agotado' : 'Producto disponible', next ? 'warning' : 'success')
+
+      // Si acabamos de marcar agotado y duró mucho menos de lo esperado,
+      // ofrecemos ajustar unidades o frecuencia.
+      if (next && updated?.last_purchased_at && updated?.reminder_frequency_days > 0) {
+        const lastPurchase = new Date(updated.last_purchased_at).getTime()
+        const actualDays = Math.max(1, Math.round((Date.now() - lastPurchase) / (24 * 3600 * 1000)))
+        const threshold = updated.reminder_frequency_days * EARLY_OUT_OF_STOCK_RATIO
+        if (actualDays < threshold) {
+          setEarlyOutModal({ product: updated, actualDays })
+        }
+      }
+    } catch { showToast('Error al actualizar', 'error') }
+  }
+
+  async function handleAdjustUnits(productId, newUnits) {
+    try {
+      await updateProduct(productId, { units: newUnits })
+      setEarlyOutModal(null)
+      loadProducts()
+      showToast('Unidades actualizadas')
+    } catch { showToast('Error al actualizar', 'error') }
+  }
+
+  async function handleAdjustFrequency(productId, newFrequency) {
+    try {
+      await updateProduct(productId, { reminder_frequency_days: newFrequency })
+      setEarlyOutModal(null)
+      loadProducts()
+      showToast('Frecuencia actualizada')
     } catch { showToast('Error al actualizar', 'error') }
   }
 
@@ -278,6 +313,18 @@ export default function Products() {
         </div>,
         document.body
       )}
+
+      {/* Early out-of-stock modal */}
+      {earlyOutModal && createPortal(
+        <EarlyOutOfStockModal
+          product={earlyOutModal.product}
+          actualDays={earlyOutModal.actualDays}
+          onAdjustUnits={handleAdjustUnits}
+          onAdjustFrequency={handleAdjustFrequency}
+          onClose={() => setEarlyOutModal(null)}
+        />,
+        document.body
+      )}
     </div>
   )
 }
@@ -371,6 +418,23 @@ function ProductCard({ product, deletingId, onEdit, onDelete, onToggleOutOfStock
                 </svg>
                 Cada {product.reminder_frequency_days}d
               </span>
+
+              {/* Units badge */}
+              {product.units > 1 && (
+                <span
+                  className="freq-badge"
+                  style={{
+                    background: 'rgba(196,184,166,0.15)',
+                    color: 'var(--bark-400)',
+                  }}
+                >
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
+                    <path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/>
+                    <path d="M3.27 6.96L12 12.01l8.73-5.05M12 22.08V12"/>
+                  </svg>
+                  {product.units}u
+                </span>
+              )}
             </div>
           </div>
         </div>
@@ -462,6 +526,7 @@ function ProductForm({ product, onSave, onCancel }) {
   const [name, setName] = useState(product?.name || '')
   const [category, setCategory] = useState(product?.category || 'general')
   const [frequencyDays, setFrequencyDays] = useState(product?.reminder_frequency_days || 30)
+  const [units, setUnits] = useState(product?.units || 1)
   const [isOutOfStock, setIsOutOfStock] = useState(product?.is_out_of_stock || false)
 
   function handleSubmit(e) {
@@ -471,6 +536,7 @@ function ProductForm({ product, onSave, onCancel }) {
       name: name.trim(),
       category,
       reminder_frequency_days: parseInt(frequencyDays) || 30,
+      units: Math.max(1, parseInt(units) || 1),
       is_out_of_stock: isOutOfStock,
     })
   }
@@ -570,6 +636,29 @@ function ProductForm({ product, onSave, onCancel }) {
         </div>
       </div>
 
+      {/* Units per purchase */}
+      <div>
+        <label className="block font-body text-[12px] font-semibold uppercase tracking-wider mb-1.5" style={{ color: 'var(--bark-300)' }}>
+          Unidades por compra
+        </label>
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            min="1"
+            max="99"
+            value={units}
+            onChange={e => setUnits(e.target.value)}
+            className="w-20 px-3 py-2 rounded-xl font-body text-[14px] text-center outline-none"
+            style={{
+              background: 'var(--surface-elevated)',
+              border: '1.5px solid rgba(196,184,166,0.3)',
+              color: 'var(--bark-700)',
+            }}
+          />
+          <span className="font-body text-[13px]" style={{ color: 'var(--bark-300)' }}>Ej: 4 rollos, 2 frascos</span>
+        </div>
+      </div>
+
       {/* Out of stock toggle */}
       <div className="flex items-center justify-between p-3 rounded-xl" style={{ background: 'var(--surface-elevated)', border: '1.5px solid rgba(196,184,166,0.3)' }}>
         <div>
@@ -608,5 +697,118 @@ function ProductForm({ product, onSave, onCancel }) {
         </button>
       </div>
     </form>
+  )
+}
+
+function EarlyOutOfStockModal({ product, actualDays, onAdjustUnits, onAdjustFrequency, onClose }) {
+  const [newUnits, setNewUnits] = useState(Math.max(1, (product.units || 1) - 1))
+  const [newFrequency, setNewFrequency] = useState(actualDays)
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center sm:items-center sm:p-4 modal-backdrop"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg rounded-t-2xl sm:rounded-2xl p-5 max-h-[92dvh] overflow-y-auto fade-in"
+        style={{ background: 'var(--surface-card)', border: '1px solid rgba(196,184,166,0.25)' }}
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-start gap-3 mb-4">
+          <div className="flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center text-lg" style={{ background: 'rgba(184,90,58,0.1)' }}>
+            ⚡
+          </div>
+          <div>
+            <h3 className="font-display text-[20px] leading-tight" style={{ color: 'var(--bark-700)' }}>
+              Se agoto antes de tiempo
+            </h3>
+            <p className="font-body text-[13px] mt-1" style={{ color: 'var(--bark-400)' }}>
+              <strong style={{ color: 'var(--bark-700)' }}>{product.name}</strong> duro {actualDays} {actualDays === 1 ? 'dia' : 'dias'}, pero lo tenias configurado cada {product.reminder_frequency_days} dias.
+            </p>
+          </div>
+        </div>
+
+        <p className="font-body text-[12px] font-semibold uppercase tracking-wider mb-3" style={{ color: 'var(--bark-300)' }}>
+          Que paso?
+        </p>
+
+        {/* Option 1: update units */}
+        <div className="rounded-xl p-4 mb-2.5" style={{ background: 'var(--surface-elevated)', border: '1.5px solid rgba(196,184,166,0.3)' }}>
+          <div className="flex items-start gap-2 mb-3">
+            <span className="text-lg leading-none mt-0.5">📦</span>
+            <div>
+              <p className="font-body font-semibold text-[14px]" style={{ color: 'var(--bark-700)' }}>Use menos unidades</p>
+              <p className="font-body text-[12px] mt-0.5" style={{ color: 'var(--bark-400)' }}>
+                Tenias {product.units} {product.units === 1 ? 'unidad' : 'unidades'} configuradas
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              min="1"
+              max="99"
+              value={newUnits}
+              onChange={e => setNewUnits(e.target.value)}
+              className="w-20 px-3 py-2 rounded-xl font-body text-[14px] text-center outline-none"
+              style={{ background: 'var(--surface-card)', border: '1.5px solid rgba(196,184,166,0.3)', color: 'var(--bark-700)' }}
+            />
+            <span className="font-body text-[13px]" style={{ color: 'var(--bark-300)' }}>unidades</span>
+            <button
+              type="button"
+              onClick={() => onAdjustUnits(product.id, Math.max(1, parseInt(newUnits) || 1))}
+              className="ml-auto px-3.5 py-2 rounded-xl font-body font-semibold text-[13px] text-white active:scale-95 transition-all"
+              style={{ background: 'var(--moss-500)' }}
+            >
+              Actualizar
+            </button>
+          </div>
+        </div>
+
+        {/* Option 2: update frequency */}
+        <div className="rounded-xl p-4 mb-3" style={{ background: 'var(--surface-elevated)', border: '1.5px solid rgba(196,184,166,0.3)' }}>
+          <div className="flex items-start gap-2 mb-3">
+            <span className="text-lg leading-none mt-0.5">🔄</span>
+            <div>
+              <p className="font-body font-semibold text-[14px]" style={{ color: 'var(--bark-700)' }}>Dura menos en mi casa</p>
+              <p className="font-body text-[12px] mt-0.5" style={{ color: 'var(--bark-400)' }}>
+                Ajustar recordatorio de {product.reminder_frequency_days} a lo que realmente dura
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              min="1"
+              max="365"
+              value={newFrequency}
+              onChange={e => setNewFrequency(e.target.value)}
+              className="w-20 px-3 py-2 rounded-xl font-body text-[14px] text-center outline-none"
+              style={{ background: 'var(--surface-card)', border: '1.5px solid rgba(196,184,166,0.3)', color: 'var(--bark-700)' }}
+            />
+            <span className="font-body text-[13px]" style={{ color: 'var(--bark-300)' }}>dias</span>
+            <button
+              type="button"
+              onClick={() => onAdjustFrequency(product.id, Math.max(1, parseInt(newFrequency) || 1))}
+              className="ml-auto px-3.5 py-2 rounded-xl font-body font-semibold text-[13px] text-white active:scale-95 transition-all"
+              style={{ background: 'var(--moss-500)' }}
+            >
+              Actualizar
+            </button>
+          </div>
+        </div>
+
+        {/* Dismiss */}
+        <button
+          type="button"
+          onClick={onClose}
+          className="w-full px-4 py-2.5 rounded-xl font-body font-semibold text-[13px] transition-all"
+          style={{ color: 'var(--bark-400)', border: '1.5px solid rgba(196,184,166,0.3)' }}
+        >
+          Solo agotarlo
+        </button>
+      </div>
+    </div>
   )
 }

--- a/server/index.js
+++ b/server/index.js
@@ -621,12 +621,12 @@ app.get('/api/products', requireAuth, requireHouse, async (req, res) => {
 // POST /api/products
 app.post('/api/products', requireAuth, requireHouse, async (req, res) => {
   try {
-    const { name, category, reminder_frequency_days, is_out_of_stock } = req.body
+    const { name, category, reminder_frequency_days, is_out_of_stock, units } = req.body
     if (!name?.trim()) return res.status(400).json({ error: 'name is required' })
     const { rows } = await pool.query(
-      `INSERT INTO products (name, category, reminder_frequency_days, is_out_of_stock, organization_id)
-       VALUES ($1, $2, $3, $4, $5) RETURNING *`,
-      [name.trim(), category || 'general', reminder_frequency_days || 30, is_out_of_stock ?? false, req.house.id]
+      `INSERT INTO products (name, category, reminder_frequency_days, is_out_of_stock, units, organization_id)
+       VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
+      [name.trim(), category || 'general', reminder_frequency_days || 30, is_out_of_stock ?? false, Math.max(1, parseInt(units) || 1), req.house.id]
     )
     res.json(rows[0])
   } catch (err) {
@@ -638,8 +638,16 @@ app.post('/api/products', requireAuth, requireHouse, async (req, res) => {
 app.patch('/api/products/:id', requireAuth, requireHouse, async (req, res) => {
   try {
     const { id } = req.params
-    const fields = req.body
-    const keys = Object.keys(fields).filter(k => k !== 'organization_id')
+    const fields = { ...req.body }
+    delete fields.organization_id
+
+    // Cuando cambia is_out_of_stock, sincronizamos el timestamp de agotado
+    // sin que el cliente tenga que pasarlo explícitamente.
+    if ('is_out_of_stock' in fields) {
+      fields.last_out_of_stock_at = fields.is_out_of_stock ? new Date() : null
+    }
+
+    const keys = Object.keys(fields)
     if (keys.length === 0) return res.status(400).json({ error: 'No fields to update' })
 
     const setClauses = keys.map((k, i) => `${k} = $${i + 3}`)
@@ -661,7 +669,9 @@ app.post('/api/products/:id/purchase', requireAuth, requireHouse, async (req, re
   try {
     const { id } = req.params
     const { rows } = await pool.query(
-      `UPDATE products SET last_purchased_at = NOW(), is_out_of_stock = false WHERE id = $1 AND organization_id = $2 RETURNING *`,
+      `UPDATE products
+       SET last_purchased_at = NOW(), is_out_of_stock = false, last_out_of_stock_at = NULL
+       WHERE id = $1 AND organization_id = $2 RETURNING *`,
       [id, req.house.id]
     )
     if (rows.length === 0) return res.status(404).json({ error: 'Product not found' })
@@ -1084,6 +1094,9 @@ async function migrate() {
     await addColumnIfMissing('tasks', 'product_image', 'TEXT')
     // Reset de aparición sin borrar historial
     await addColumnIfMissing('tasks', 'last_reset_at', 'TIMESTAMPTZ')
+    // Unidades compradas por vez + timestamp de agotado para detectar consumo acelerado
+    await addColumnIfMissing('products', 'units', 'INTEGER NOT NULL DEFAULT 1')
+    await addColumnIfMissing('products', 'last_out_of_stock_at', 'TIMESTAMPTZ')
 
     // Multi-tenant columns
     await addColumnIfMissing('tasks', 'organization_id', 'TEXT')


### PR DESCRIPTION
- Nueva columna products.units para registrar unidades por compra
- Nueva columna products.last_out_of_stock_at, gestionada
  automaticamente desde el PATCH y la compra
- Al marcar agotado, si el producto duro < 60% de su frecuencia,
  se abre un modal para ajustar unidades o frecuencia
- Opcion "Solo agotarlo" descarta el ajuste sin tocar nada