### PR TITLE
feat(invitations): gestionar invitaciones pendientes desde Configuración

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,14 @@
 
 ## [Fase 0] — MVP Fundacional
 
+### 2026-05-01 — Gestión de invitaciones pendientes
+- **Sección "Invitaciones pendientes" en Configuración de la casa** — owners y admins ven, debajo del formulario de invitar, la lista de invitaciones con estado `pending`: email, rol y tiempo restante hasta la expiración (formato relativo: "Expira en 3 dias", "Expira manana", "Expirada" en clay si ya venció).
+- **Renovar invitación** — botón con icono de refresco extiende `expiresAt` por 7 días desde ahora (`POST /api/invitations/:id/renew`). Útil cuando la invitación expiró y quieres darle nueva vida sin reinvitar desde cero.
+- **Eliminar invitación** — botón X con doble-tap de confirmación (3s timeout, mismo patrón que eliminar miembro y eliminar casa) revoca una invitación pendiente (`DELETE /api/invitations/:id`).
+- **Endpoints backend protegidos** — `GET/DELETE/POST /api/invitations*` con stack `requireAuth → requireHouse → requireRole('owner','admin')`. Toda query filtra por `req.house.id` (regla crítica #1 multi-tenant) y `status = 'pending'`. SQL parametrizado (regla crítica #2).
+- **Refresh automático** — al enviar una nueva invitación desde el formulario existente, la lista se recarga sin necesidad de recargar la página.
+- Archivos: `server/index.js` (3 endpoints nuevos sobre tabla better-auth `"invitation"`), `frontend/src/lib/api.js` (`fetchInvitations`, `renewInvitation`, `deleteInvitation`), `frontend/src/pages/HouseSettings.jsx` (nueva sección y handlers).
+
 ### 2026-05-01 — Navegación con menú hamburguesa
 - **Reemplazo de la nav scrollable por drawer lateral** — el header ya no muestra una barra horizontal con scroll para acceder a los módulos (Tareas, Stats, Productos, Plantas, Compras, Admin, Casa). Ahora un botón hamburguesa abre un drawer desde la izquierda con todos los módulos como items grandes.
 - **Mejora UX mobile** — tap targets ≥ 44px, indicador visual del módulo activo (barra lateral con `activeColor` de cada módulo), backdrop con blur, cierre con tap fuera / Escape / selección de item, `body` con `overflow:hidden` mientras el drawer está abierto.

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -257,3 +257,17 @@ export async function seedHouse(template = 'small', tasks = null) {
 export async function deleteHouse(houseId) {
   return request(`/houses/${houseId}`, { method: 'DELETE' })
 }
+
+// --- Invitations ---
+
+export async function fetchInvitations() {
+  return request('/invitations')
+}
+
+export async function deleteInvitation(id) {
+  return request(`/invitations/${id}`, { method: 'DELETE' })
+}
+
+export async function renewInvitation(id) {
+  return request(`/invitations/${id}/renew`, { method: 'POST' })
+}

--- a/frontend/src/pages/HouseSettings.jsx
+++ b/frontend/src/pages/HouseSettings.jsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router-dom'
 import { authClient } from '../lib/auth'
 import { getActiveHouse, setActiveHouse, clearActiveHouse, AVATARS, COLORS } from '../lib/house'
-import { fetchHouseMembers, fetchHouseProfile, updateHouseProfile, fetchVapidKey, subscribePush, unsubscribePush, fetchPushStatus, deleteHouse } from '../lib/api'
+import { fetchHouseMembers, fetchHouseProfile, updateHouseProfile, fetchVapidKey, subscribePush, unsubscribePush, fetchPushStatus, deleteHouse, fetchInvitations, deleteInvitation, renewInvitation } from '../lib/api'
 
 export default function HouseSettings() {
   const navigate = useNavigate()
@@ -26,6 +26,9 @@ export default function HouseSettings() {
   const [pushLoading, setPushLoading] = useState(false)
   const [confirmingDelete, setConfirmingDelete] = useState(false)
   const [deletingHouse, setDeletingHouse] = useState(false)
+  const [invitations, setInvitations] = useState([])
+  const [confirmingDeleteInvId, setConfirmingDeleteInvId] = useState(null)
+  const [actingInvId, setActingInvId] = useState(null)
   const { data: session } = authClient.useSession()
 
   const showToast = (msg, type = 'success') => {
@@ -42,12 +45,74 @@ export default function HouseSettings() {
       setMembers(membersData)
       setMyProfile(profileData)
       const me = membersData.find(m => m.userId === session?.user?.id)
-      if (me) setMyRole(me.role)
+      if (me) {
+        setMyRole(me.role)
+        if (me.role === 'owner' || me.role === 'admin') {
+          loadInvitations()
+        }
+      }
     } catch {
       showToast('Error al cargar datos', 'error')
     } finally {
       setLoading(false)
     }
+  }
+
+  async function loadInvitations() {
+    try {
+      const data = await fetchInvitations()
+      setInvitations(data)
+    } catch {
+      // Silently ignore - non-admins won't have access
+    }
+  }
+
+  async function handleRenewInvitation(id) {
+    setActingInvId(id)
+    try {
+      await renewInvitation(id)
+      showToast('Invitacion renovada 7 dias mas')
+      loadInvitations()
+    } catch (err) {
+      showToast(err.message || 'Error al renovar invitacion', 'error')
+    } finally {
+      setActingInvId(null)
+    }
+  }
+
+  async function handleDeleteInvitation(id) {
+    if (confirmingDeleteInvId !== id) {
+      setConfirmingDeleteInvId(id)
+      setTimeout(() => setConfirmingDeleteInvId(null), 3000)
+      return
+    }
+    setActingInvId(id)
+    try {
+      await deleteInvitation(id)
+      showToast('Invitacion eliminada', 'warning')
+      loadInvitations()
+    } catch (err) {
+      showToast(err.message || 'Error al eliminar invitacion', 'error')
+    } finally {
+      setActingInvId(null)
+      setConfirmingDeleteInvId(null)
+    }
+  }
+
+  function formatExpiry(expiresAt) {
+    if (!expiresAt) return ''
+    const exp = new Date(expiresAt)
+    const now = new Date()
+    const diffMs = exp - now
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+    if (diffMs < 0) return 'Expirada'
+    if (diffDays === 0) {
+      const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
+      if (diffHours <= 0) return 'Expira pronto'
+      return `Expira en ${diffHours}h`
+    }
+    if (diffDays === 1) return 'Expira manana'
+    return `Expira en ${diffDays} dias`
   }
 
   useEffect(() => {
@@ -114,6 +179,7 @@ export default function HouseSettings() {
       } else {
         showToast('Invitacion enviada')
         setInviteEmail('')
+        loadInvitations()
       }
     } catch (err) {
       showToast(err.message || 'Error al invitar', 'error')
@@ -445,6 +511,89 @@ export default function HouseSettings() {
               {inviting ? 'Invitando...' : 'Enviar invitacion'}
             </button>
           </form>
+        </div>
+      )}
+
+      {/* Pending invitations */}
+      {isOwnerOrAdmin && invitations.length > 0 && (
+        <div className="mb-6">
+          <h3 className="font-display text-lg mb-3" style={{ color: 'var(--bark-700)' }}>
+            Invitaciones pendientes ({invitations.length})
+          </h3>
+          <div className="flex flex-col gap-2">
+            {invitations.map(inv => {
+              const expired = inv.expiresAt && new Date(inv.expiresAt) < new Date()
+              const acting = actingInvId === inv.id
+              const confirmingDelete = confirmingDeleteInvId === inv.id
+              return (
+                <div
+                  key={inv.id}
+                  className="flex items-center gap-3 p-3 rounded-xl"
+                  style={{ background: 'var(--surface-card)', border: '1px solid rgba(196,184,166,0.25)' }}
+                >
+                  <div
+                    className="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0"
+                    style={{ background: 'rgba(196,184,166,0.15)', color: 'var(--bark-400)' }}
+                  >
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/>
+                      <polyline points="22,6 12,13 2,6"/>
+                    </svg>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-body font-semibold text-[13px] truncate" style={{ color: 'var(--bark-700)' }}>
+                      {inv.email}
+                    </p>
+                    <div className="flex items-center gap-1.5 mt-0.5">
+                      <span
+                        className="px-1.5 py-0.5 rounded text-[10px] font-body font-semibold"
+                        style={{ ...roleColor(inv.role) }}
+                      >
+                        {roleLabel(inv.role)}
+                      </span>
+                      <span
+                        className="font-body text-[11px]"
+                        style={{ color: expired ? 'var(--clay-500)' : 'var(--bark-300)' }}
+                      >
+                        {formatExpiry(inv.expiresAt)}
+                      </span>
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => handleRenewInvitation(inv.id)}
+                    disabled={acting}
+                    title="Renovar 7 dias"
+                    className="flex-shrink-0 w-8 h-8 rounded-md flex items-center justify-center transition-all active:scale-90 disabled:opacity-50"
+                    style={{ color: 'var(--moss-500)', background: 'rgba(106,153,96,0.08)' }}
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <polyline points="23 4 23 10 17 10"/>
+                      <polyline points="1 20 1 14 7 14"/>
+                      <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/>
+                    </svg>
+                  </button>
+                  <button
+                    onClick={() => handleDeleteInvitation(inv.id)}
+                    disabled={acting}
+                    title="Eliminar invitacion"
+                    className="flex-shrink-0 w-8 h-8 rounded-md flex items-center justify-center transition-all active:scale-90 disabled:opacity-50"
+                    style={{
+                      color: confirmingDelete ? 'white' : 'var(--clay-500)',
+                      background: confirmingDelete ? 'var(--clay-500)' : 'rgba(184,90,58,0.08)',
+                    }}
+                  >
+                    {confirmingDelete ? (
+                      <span className="font-body font-bold text-[10px]">?</span>
+                    ) : (
+                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                        <path d="M18 6L6 18M6 6l12 12"/>
+                      </svg>
+                    )}
+                  </button>
+                </div>
+              )
+            })}
+          </div>
         </div>
       )}
 

--- a/server/index.js
+++ b/server/index.js
@@ -204,6 +204,58 @@ app.put('/api/houses/profile', requireAuth, requireHouse, async (req, res) => {
   }
 })
 
+// GET /api/invitations - list pending invitations for active house (owner/admin only)
+app.get('/api/invitations', requireAuth, requireHouse, requireRole('owner', 'admin'), async (req, res) => {
+  try {
+    const { rows } = await pool.query(`
+      SELECT i.id, i.email, i.role, i.status, i."expiresAt", i."inviterId",
+             u.name as inviter_name, u.email as inviter_email
+      FROM "invitation" i
+      LEFT JOIN "user" u ON u.id = i."inviterId"
+      WHERE i."organizationId" = $1 AND i.status = 'pending'
+      ORDER BY i."expiresAt" DESC
+    `, [req.house.id])
+    res.json(rows)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// DELETE /api/invitations/:id - revoke a pending invitation (owner/admin only)
+app.delete('/api/invitations/:id', requireAuth, requireHouse, requireRole('owner', 'admin'), async (req, res) => {
+  try {
+    const { rowCount } = await pool.query(
+      `DELETE FROM "invitation" WHERE id = $1 AND "organizationId" = $2 AND status = 'pending'`,
+      [req.params.id, req.house.id]
+    )
+    if (rowCount === 0) {
+      return res.status(404).json({ error: 'Invitacion no encontrada' })
+    }
+    res.json({ ok: true })
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// POST /api/invitations/:id/renew - extend expiration by 7 days (owner/admin only)
+app.post('/api/invitations/:id/renew', requireAuth, requireHouse, requireRole('owner', 'admin'), async (req, res) => {
+  try {
+    const { rows } = await pool.query(
+      `UPDATE "invitation"
+       SET "expiresAt" = NOW() + INTERVAL '7 days'
+       WHERE id = $1 AND "organizationId" = $2 AND status = 'pending'
+       RETURNING id, email, role, status, "expiresAt"`,
+      [req.params.id, req.house.id]
+    )
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Invitacion no encontrada' })
+    }
+    res.json(rows[0])
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
 // DELETE /api/houses/:id - delete a house and all its data (owner only)
 app.delete('/api/houses/:id', requireAuth, async (req, res) => {
   const houseId = req.params.id


### PR DESCRIPTION
Owners y admins pueden ver, renovar (+7 días) y eliminar invitaciones pendientes
de su casa desde HouseSettings, debajo del formulario de invitar.

- 3 endpoints REST sobre tabla better-auth "invitation" filtrados por
  organization_id y status='pending', protegidos con requireRole('owner','admin')
- Lista visual con email, rol, tiempo de expiración relativo (clay si expirada)
- Doble-tap para confirmar eliminación (mismo patrón que remover miembro)
- Refresh automático tras enviar nueva invitación