### PR TITLE
feat(shopping): archivar compras + recomendador por periodicidad

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -62,12 +62,16 @@ CREATE TABLE IF NOT EXISTS shopping_items (
     is_purchased BOOLEAN NOT NULL DEFAULT false,
     category_id UUID REFERENCES shopping_categories(id) ON DELETE SET NULL,
     organization_id TEXT,
+    purchased_at TIMESTAMPTZ,
+    archived_at  TIMESTAMPTZ,
     created_at  TIMESTAMPTZ DEFAULT NOW()
 );
 
 CREATE INDEX IF NOT EXISTS idx_shopping_items_purchased ON shopping_items(is_purchased);
 CREATE INDEX IF NOT EXISTS idx_shopping_items_org ON shopping_items(organization_id);
 CREATE INDEX IF NOT EXISTS idx_shopping_items_category ON shopping_items(category_id);
+CREATE INDEX IF NOT EXISTS idx_shopping_items_archived ON shopping_items(archived_at);
+CREATE INDEX IF NOT EXISTS idx_shopping_items_purchased_at ON shopping_items(purchased_at DESC);
 
 CREATE TABLE IF NOT EXISTS house_member_profiles (
     id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,23 @@
 
 ---
 
+## [Fase 2] — Experiencias Agénticas
+
+### 2026-05-17 — Archivado de compras + recomendador por periodicidad
+- **Compras dejan historial en vez de borrarse** — `shopping_items` gana columnas `purchased_at` (se setea automaticamente al marcar `is_purchased=true`, se limpia al desmarcar) y `archived_at` (marca el item como archivado, lo saca de la lista activa). Migracion automatica en `migrate()` + `init.sql` para installs nuevos.
+- **Auto-archivado lazy a los 7 dias** — `GET /api/shopping-items` corre un `UPDATE` previo que archiva los comprados con `purchased_at` mayor a 7 dias. Sin cron, sin worker: aprovecha el trafico normal de la lista. La lista activa filtra por `archived_at IS NULL`.
+- **`DELETE /shopping-items/clear-purchased` ahora archiva** — antes borraba (perdiamos historial). Ahora hace `UPDATE … SET archived_at = NOW()`, y rellena `purchased_at` con `COALESCE` para items legacy sin timestamp. El boton del frontend se renombro a "Archivar".
+- **`GET /api/shopping-items/recommendations`** — analiza items archivados agrupados por nombre normalizado (sin acentos, lower). Para cada grupo con >= 2 compras calcula la **mediana** de los intervalos historicos, predice la proxima compra y la incluye si esta dentro de la ventana de tolerancia (3 dias antes o vencida). Excluye items que ya estan en la lista activa. Mediana > media para resistir outliers (compras compulsivas no rompen la frecuencia base).
+- **`GET /api/shopping-items/history`** — items archivados, ordenados por `archived_at DESC`, limite 1-500 (default 100).
+- **Seccion "Sugeridos para volver a comprar" en `/shopping`** — colapsable, muestra emoji de categoria, status (`Vencido hace N dias` / `Toca recomprar` / `En N dias`), intervalo promedio y veces compradas. Cada sugerencia tiene boton `+ Agregar` (hereda category_id del historico) y `X` para descartar en la sesion.
+- **Nueva pagina `/shopping/history`** — historial agrupado por mes, con buscador y filtro por categoria. Acceso desde un nuevo boton (icono de reloj con flecha circular) en el header de la lista.
+- **Hardening de seguridad** — `purchased_at` y `archived_at` agregados al whitelist `SHOPPING_ITEM_UPDATABLE_COLUMNS`, pero el handler `PATCH /shopping-items/:id` sobreescribe lo que mande el cliente cuando viene `is_purchased`, para garantizar consistencia. Multi-tenant respetado: todas las queries filtran por `req.house.id` (regla critica #1) y usan parametros (#2).
+- **Tests** — `server/lib/shopping-recommendations.test.js` cubre normalizacion, exclusion de items activos, ordenamiento por urgencia, mediana vs media, requisito de >= 2 compras y tolerancia de ventana. `frontend/src/pages/__tests__/ShoppingList.test.jsx` extiende mocks y agrega 3 casos: render de la seccion, click en "Agregar" sobre una recomendacion y ausencia de la seccion cuando no hay recomendaciones.
+- **Cierra una sub-meta de Fase 2** — junto con Smart Tags y el recomendador de tareas en onboarding, completa la trilogia de experiencias agenticas sobre compras/tareas. Habilita futuras notificaciones push tipo "se acerca tu recompra de X" sin trabajo adicional de modelado.
+- Archivos: `db/init.sql`, `server/index.js`, `server/lib/patch-update.js`, `server/lib/shopping-recommendations.js` (nuevo), `server/lib/shopping-recommendations.test.js` (nuevo), `frontend/src/lib/api.js`, `frontend/src/pages/ShoppingList.jsx`, `frontend/src/pages/ShoppingHistory.jsx` (nuevo), `frontend/src/main.jsx`.
+
+---
+
 ## [Fase 0] — MVP Fundacional
 
 ### 2026-05-01 — Gestión de invitaciones pendientes

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -391,9 +391,9 @@
       }
     },
     "node_modules/@better-auth/core": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.5.6.tgz",
-      "integrity": "sha512-Ez9DZdIMFyxHremmoLz1emFPGNQomDC1jqqBPnZ6Ci+6TiGN3R9w/Y03cJn6I8r1ycKgOzeVMZtJ/erOZ27Gsw==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.11.tgz",
+      "integrity": "sha512-LrwidLCV8azdMGjvtwp30nj9tIv1BwI3VhtC0UaGSjQkAVWw4bN42I8qwbxRziPeSQoj+zUVkOpxZzAWBDARtQ==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.39.0",
@@ -401,11 +401,11 @@
         "zod": "^4.3.6"
       },
       "peerDependencies": {
-        "@better-auth/utils": "0.3.1",
+        "@better-auth/utils": "0.4.0",
         "@better-fetch/fetch": "1.1.21",
         "@cloudflare/workers-types": ">=4",
         "@opentelemetry/api": "^1.9.0",
-        "better-call": "1.3.2",
+        "better-call": "1.3.5",
         "jose": "^6.1.0",
         "kysely": "^0.28.5",
         "nanostores": "^1.0.1"
@@ -413,18 +413,21 @@
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
           "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
         }
       }
     },
     "node_modules/@better-auth/kysely-adapter": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.5.6.tgz",
-      "integrity": "sha512-Fnf+h8WVKtw6lEOmVmiVVzDf3shJtM60AYf9XTnbdCeUd6MxN/KnaJZpkgtYnRs7a+nwtkVB+fg4lGETebGFXQ==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.11.tgz",
+      "integrity": "sha512-/g8M9RfIjdcZDnbstSUvQiINkvdNlCeZr248zwqx2/PVksQI1MhQofbzUn3RnQnbPKp0EPwpX/dR3oudRFenUg==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.6",
-        "@better-auth/utils": "^0.3.0",
-        "kysely": "^0.27.0 || ^0.28.0"
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0",
+        "kysely": "^0.28.17"
       },
       "peerDependenciesMeta": {
         "kysely": {
@@ -433,23 +436,23 @@
       }
     },
     "node_modules/@better-auth/memory-adapter": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.5.6.tgz",
-      "integrity": "sha512-rS7ZsrIl5uvloUgNN0u9LOZJMMXnsZXVdUZ3MrTBKWM2KpoJjzPr9yN3Szyma5+0V7SltnzSGHPkYj2bEzzmlA==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.11.tgz",
+      "integrity": "sha512-hpdfw0BBf8MuzLkIdmbcUZICbY9r/bhLO2RxSnkzT5+/O+0I0u2I8+m0YUP7vNllP/ZCKASHOYgXPLO75Z0f9Q==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.6",
-        "@better-auth/utils": "^0.3.0"
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0"
       }
     },
     "node_modules/@better-auth/mongo-adapter": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.5.6.tgz",
-      "integrity": "sha512-6+M3MS2mor8fTUV3EI1FBLP0cs6QfbN+Ovx9+XxR/GdfKIBoNFzmPEPRbdGt+ft6PvrITsUm+T70+kkHgVSP6w==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.11.tgz",
+      "integrity": "sha512-3Tor8rSv8vSEIMEaV2PFpPEuVhqc1gNoZ6eGvoh3LwExXXuj8madew6ob+H1pH7Aphn3Ar5PQ08AguT8TbwFAA==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.6",
-        "@better-auth/utils": "^0.3.0",
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0",
         "mongodb": "^6.0.0 || ^7.0.0"
       },
       "peerDependenciesMeta": {
@@ -459,13 +462,13 @@
       }
     },
     "node_modules/@better-auth/prisma-adapter": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.5.6.tgz",
-      "integrity": "sha512-UxY9vQJs1Tt+O+T2YQnseDMlWmUSQvFZSBb5YiFRg7zcm+TEzujh4iX2/csA0YiZptLheovIuVWTP9nriewEBA==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.11.tgz",
+      "integrity": "sha512-Pw+7q7zTp+VSci1V+CYMvuxIbAeVMZLe4lRo46LJoAKMHfjFl5T/ycsyFvWs/DkWC7n9gZZzRDEbHp0I5FiKKw==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.6",
-        "@better-auth/utils": "^0.3.0",
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0",
         "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
       },
@@ -479,23 +482,24 @@
       }
     },
     "node_modules/@better-auth/telemetry": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.5.6.tgz",
-      "integrity": "sha512-yXC7NSxnIFlxDkGdpD7KA+J9nqIQAPCJKe77GoaC5bWoe/DALo1MYorZfTgOafS7wrslNtsPT4feV/LJi1ubqQ==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.11.tgz",
+      "integrity": "sha512-hsjDHc8MZbm6/AHeNdtywrWedXevnBjmdvnHTcZub+rTVjOv+Td0roI8USKuC6uUibmrl//2rJfVCsGbopihNA==",
       "license": "MIT",
-      "dependencies": {
-        "@better-auth/utils": "0.3.1",
-        "@better-fetch/fetch": "1.1.21"
-      },
       "peerDependencies": {
-        "@better-auth/core": "1.5.6"
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21"
       }
     },
     "node_modules/@better-auth/utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.1.tgz",
-      "integrity": "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg==",
-      "license": "MIT"
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.0.tgz",
+      "integrity": "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1"
+      }
     },
     "node_modules/@better-fetch/fetch": {
       "version": "1.1.21",
@@ -1288,15 +1292,16 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
-      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -2429,26 +2434,26 @@
       }
     },
     "node_modules/better-auth": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.5.6.tgz",
-      "integrity": "sha512-QSpJTqaT1XVfWRQe/fm3PgeuwOIlz1nWX/Dx7nsHStJ382bLzmDbQk2u7IT0IJ6wS5SRxfqEE1Ev9TXontgyAQ==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.11.tgz",
+      "integrity": "sha512-Wwt6+q07dwIhsp6XiM7L1qSXVUWBEtNl+eZvwM778CguFqDZFBN9Pt6LtFaHl55t8Z+Zc//5kxcbgDY8/79vFQ==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.5.6",
-        "@better-auth/drizzle-adapter": "1.5.6",
-        "@better-auth/kysely-adapter": "1.5.6",
-        "@better-auth/memory-adapter": "1.5.6",
-        "@better-auth/mongo-adapter": "1.5.6",
-        "@better-auth/prisma-adapter": "1.5.6",
-        "@better-auth/telemetry": "1.5.6",
-        "@better-auth/utils": "0.3.1",
+        "@better-auth/core": "1.6.11",
+        "@better-auth/drizzle-adapter": "1.6.11",
+        "@better-auth/kysely-adapter": "1.6.11",
+        "@better-auth/memory-adapter": "1.6.11",
+        "@better-auth/mongo-adapter": "1.6.11",
+        "@better-auth/prisma-adapter": "1.6.11",
+        "@better-auth/telemetry": "1.6.11",
+        "@better-auth/utils": "0.4.0",
         "@better-fetch/fetch": "1.1.21",
         "@noble/ciphers": "^2.1.1",
         "@noble/hashes": "^2.0.1",
-        "better-call": "1.3.2",
+        "better-call": "1.3.5",
         "defu": "^6.1.4",
         "jose": "^6.1.3",
-        "kysely": "^0.28.12",
+        "kysely": "^0.28.17",
         "nanostores": "^1.1.1",
         "zod": "^4.3.6"
       },
@@ -2460,7 +2465,7 @@
         "@tanstack/solid-start": "^1.0.0",
         "better-sqlite3": "^12.0.0",
         "drizzle-kit": ">=0.31.4",
-        "drizzle-orm": ">=0.41.0",
+        "drizzle-orm": "^0.45.2",
         "mongodb": "^6.0.0 || ^7.0.0",
         "mysql2": "^3.0.0",
         "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
@@ -2534,14 +2539,14 @@
       }
     },
     "node_modules/better-auth/node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.5.6.tgz",
-      "integrity": "sha512-VfFFmaoFw3ug12SiSuIwzrMoHyIVmkMGWm9gZ4sXdYYVX4HboCL4m3fjzOhppcmK5OGatRuU+N1UX6wxCITcXw==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.11.tgz",
+      "integrity": "sha512-4jpkETIGZOHCf7BK4jnu22fdN6jjomH0/HhEzkaWy3+Eppi5PYlHTF/460jrTmA3Xc+Vqwp9t282ymHiEPypGw==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.6",
-        "@better-auth/utils": "^0.3.0",
-        "drizzle-orm": ">=0.41.0"
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0",
+        "drizzle-orm": "^0.45.2"
       },
       "peerDependenciesMeta": {
         "drizzle-orm": {
@@ -2550,12 +2555,12 @@
       }
     },
     "node_modules/better-call": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.2.tgz",
-      "integrity": "sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.5.tgz",
+      "integrity": "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/utils": "^0.3.1",
+        "@better-auth/utils": "^0.4.0",
         "@better-fetch/fetch": "^1.1.21",
         "rou3": "^0.7.12",
         "set-cookie-parser": "^3.0.1"
@@ -3246,9 +3251,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -3338,9 +3343,9 @@
       }
     },
     "node_modules/kysely": {
-      "version": "0.28.15",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.15.tgz",
-      "integrity": "sha512-r2clcf7HLWvDXaVUEvQymXJY4i3bSOIV3xsL/Upy3ZfSv5HeKsk9tsqbBptLvth5qHEIhxeHTA2jNLyQABkLBA==",
+      "version": "0.28.17",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.17.tgz",
+      "integrity": "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
@@ -3791,9 +3796,9 @@
       }
     },
     "node_modules/nanostores": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.2.0.tgz",
-      "integrity": "sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.3.0.tgz",
+      "integrity": "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==",
       "funding": [
         {
           "type": "github",
@@ -5612,9 +5617,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -174,6 +174,14 @@ export async function clearPurchasedItems() {
   return request('/shopping-items/clear-purchased', { method: 'DELETE' })
 }
 
+export async function fetchShoppingHistory(limit = 100) {
+  return request(`/shopping-items/history?limit=${limit}`)
+}
+
+export async function fetchShoppingRecommendations() {
+  return request('/shopping-items/recommendations')
+}
+
 // --- Plants ---
 
 export async function fetchPlants() {

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -8,6 +8,7 @@ import Products from './pages/Products'
 import Plants from './pages/Plants'
 import ShoppingList from './pages/ShoppingList'
 import ShoppingAdmin from './pages/ShoppingAdmin'
+import ShoppingHistory from './pages/ShoppingHistory'
 import Login from './pages/Login'
 import Register from './pages/Register'
 import HouseSelect from './pages/HouseSelect'
@@ -60,6 +61,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/plants" element={<Plants />} />
           <Route path="/shopping" element={<ShoppingList />} />
           <Route path="/shopping/admin" element={<ShoppingAdmin />} />
+          <Route path="/shopping/history" element={<ShoppingHistory />} />
           <Route path="/stats" element={<Stats />} />
           <Route path="/admin" element={<Admin />} />
           <Route path="/house-settings" element={<HouseSettings />} />

--- a/frontend/src/pages/ShoppingHistory.jsx
+++ b/frontend/src/pages/ShoppingHistory.jsx
@@ -1,0 +1,229 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { fetchShoppingHistory, fetchShoppingCategories } from '../lib/api'
+import SearchInput from '../components/SearchInput'
+
+export default function ShoppingHistory() {
+  const [items, setItems] = useState([])
+  const [categories, setCategories] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [query, setQuery] = useState('')
+  const [categoryFilter, setCategoryFilter] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const [hist, cats] = await Promise.all([
+          fetchShoppingHistory(200),
+          fetchShoppingCategories(),
+        ])
+        if (cancelled) return
+        setItems(hist)
+        setCategories(cats)
+      } catch {
+        if (!cancelled) setError('No se pudo cargar el historial.')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => { cancelled = true }
+  }, [])
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return items.filter(item => {
+      if (categoryFilter && item.category_id !== categoryFilter) return false
+      if (!q) return true
+      return (
+        (item.name || '').toLowerCase().includes(q) ||
+        (item.note || '').toLowerCase().includes(q) ||
+        (item.category_name || '').toLowerCase().includes(q)
+      )
+    })
+  }, [items, query, categoryFilter])
+
+  const grouped = useMemo(() => groupByMonth(filtered), [filtered])
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 gap-4 fade-in">
+        <div className="w-10 h-10 rounded-full border-[3px] border-t-transparent animate-spin" style={{ borderColor: 'rgba(184,90,58,0.2)', borderTopColor: 'transparent' }} />
+        <p className="font-body text-sm font-medium" style={{ color: 'var(--bark-300)' }}>Cargando historial...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="fade-in">
+      {/* Header */}
+      <div className="flex items-start justify-between mb-6">
+        <div>
+          <p className="font-body text-[11px] font-semibold uppercase tracking-[0.1em] mb-1.5" style={{ color: 'var(--bark-300)' }}>
+            Compras archivadas
+          </p>
+          <h2 className="font-display text-[28px] leading-none" style={{ color: 'var(--bark-700)' }}>
+            Historial
+          </h2>
+        </div>
+        <Link
+          to="/shopping"
+          className="px-3 py-2 rounded-xl font-body text-[12px] font-semibold transition-all active:scale-95"
+          style={{ background: 'rgba(196,184,166,0.15)', color: 'var(--bark-500)' }}
+        >
+          Volver
+        </Link>
+      </div>
+
+      {error && (
+        <div className="rounded-xl p-4 mb-4 font-body text-[13px]" style={{ background: 'rgba(184,90,58,0.06)', color: 'var(--clay-500)', border: '1px solid rgba(184,90,58,0.15)' }}>
+          {error}
+        </div>
+      )}
+
+      {items.length === 0 ? (
+        <div className="text-center py-12 fade-in">
+          <div className="w-14 h-14 mx-auto mb-4 rounded-2xl flex items-center justify-center text-2xl" style={{ background: 'rgba(106,153,96,0.08)' }}>
+            📦
+          </div>
+          <p className="font-display text-xl mb-1" style={{ color: 'var(--bark-700)' }}>Sin historial aun</p>
+          <p className="font-body text-sm" style={{ color: 'var(--bark-300)' }}>
+            Las compras marcadas se archivan a los 7 dias y apareceran aqui.
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* Filters */}
+          <div className="flex flex-col gap-2 mb-4">
+            <SearchInput
+              value={query}
+              onChange={setQuery}
+              placeholder="Buscar en el historial..."
+            />
+            {categories.length > 0 && (
+              <select
+                value={categoryFilter}
+                onChange={e => setCategoryFilter(e.target.value)}
+                className="px-3 py-2 rounded-xl font-body text-[13px] outline-none transition-all appearance-none cursor-pointer"
+                style={{
+                  background: 'var(--surface-card)',
+                  border: '1.5px solid rgba(196,184,166,0.3)',
+                  color: categoryFilter ? 'var(--bark-700)' : 'var(--bark-300)',
+                }}
+              >
+                <option value="">Todas las categorias</option>
+                {categories.map(cat => (
+                  <option key={cat.id} value={cat.id}>{cat.emoji} {cat.name}</option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          {filtered.length === 0 ? (
+            <div className="text-center py-10 fade-in">
+              <p className="font-body font-semibold text-[14px]" style={{ color: 'var(--bark-400)' }}>
+                Sin resultados
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-5">
+              {grouped.map(group => (
+                <div key={group.key}>
+                  <div className="flex items-center justify-between mb-2 px-1">
+                    <span className="font-body text-[12px] font-semibold uppercase tracking-wider" style={{ color: 'var(--bark-400)' }}>
+                      {group.label}
+                    </span>
+                    <span className="font-body text-[11px] font-medium px-1.5 py-0.5 rounded-full" style={{ background: 'rgba(196,184,166,0.15)', color: 'var(--bark-300)' }}>
+                      {group.items.length}
+                    </span>
+                  </div>
+                  <div className="flex flex-col gap-1.5 stagger">
+                    {group.items.map((item, i) => (
+                      <HistoryRow key={item.id} item={item} delay={i * 0.03} />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+function HistoryRow({ item, delay }) {
+  const purchasedDate = item.purchased_at ? new Date(item.purchased_at) : null
+  return (
+    <div
+      className="flex items-center gap-3 px-3.5 py-2.5 rounded-xl fade-in"
+      style={{
+        background: 'var(--surface-card)',
+        border: '1px solid rgba(196,184,166,0.2)',
+        animationDelay: `${delay}s`,
+        opacity: 0,
+        animationFillMode: 'forwards',
+      }}
+    >
+      <div
+        className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
+        style={{ background: 'rgba(106,153,96,0.1)' }}
+      >
+        <span style={{ fontSize: 14 }}>{item.category_emoji || '🛒'}</span>
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="font-body font-semibold text-[13px] leading-tight truncate" style={{ color: 'var(--bark-700)' }}>
+          {item.name}
+        </p>
+        <div className="flex items-center gap-2 mt-0.5 flex-wrap">
+          {item.category_name && (
+            <span className="font-body text-[10px] font-medium" style={{ color: 'var(--moss-500)' }}>
+              {item.category_name}
+            </span>
+          )}
+          {item.note && (
+            <span className="font-body text-[10px]" style={{ color: 'var(--bark-300)' }}>
+              {item.note}
+            </span>
+          )}
+          {item.added_by && (
+            <span className="font-body text-[10px]" style={{ color: 'var(--bark-300)' }}>
+              · {item.added_by}
+            </span>
+          )}
+        </div>
+      </div>
+      {purchasedDate && (
+        <div className="text-right flex-shrink-0">
+          <p className="font-body text-[11px] font-semibold" style={{ color: 'var(--bark-500)' }}>
+            {purchasedDate.toLocaleDateString('es-ES', { day: 'numeric', month: 'short' })}
+          </p>
+          <p className="font-body text-[10px]" style={{ color: 'var(--bark-300)' }}>
+            {purchasedDate.toLocaleDateString('es-ES', { year: 'numeric' })}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function groupByMonth(items) {
+  const map = new Map()
+  for (const item of items) {
+    const ref = item.purchased_at || item.archived_at || item.created_at
+    if (!ref) continue
+    const d = new Date(ref)
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+    if (!map.has(key)) {
+      map.set(key, {
+        key,
+        label: d.toLocaleDateString('es-ES', { month: 'long', year: 'numeric' }),
+        items: [],
+      })
+    }
+    map.get(key).items.push(item)
+  }
+  return Array.from(map.values()).sort((a, b) => (a.key < b.key ? 1 : -1))
+}

--- a/frontend/src/pages/ShoppingList.jsx
+++ b/frontend/src/pages/ShoppingList.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import {
   fetchShoppingItems, createShoppingItem, updateShoppingItem,
   deleteShoppingItem, clearPurchasedItems, fetchShoppingCategories,
+  fetchShoppingRecommendations,
 } from '../lib/api'
 import { suggestCategory } from '../lib/smartTags'
 import SearchInput from '../components/SearchInput'
@@ -10,6 +11,7 @@ import SearchInput from '../components/SearchInput'
 export default function ShoppingList() {
   const [items, setItems] = useState([])
   const [categories, setCategories] = useState([])
+  const [recommendations, setRecommendations] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [newName, setNewName] = useState('')
@@ -20,6 +22,9 @@ export default function ShoppingList() {
   const [toast, setToast] = useState(null)
   const [dismissedFor, setDismissedFor] = useState('')
   const [query, setQuery] = useState('')
+  const [dismissedRecs, setDismissedRecs] = useState(() => new Set())
+  const [recsCollapsed, setRecsCollapsed] = useState(false)
+  const [addingRecName, setAddingRecName] = useState(null)
 
   const suggestion = useMemo(() => {
     if (!newName.trim() || newCategoryId) return null
@@ -35,12 +40,14 @@ export default function ShoppingList() {
   const loadData = useCallback(async () => {
     try {
       setError(null)
-      const [itemsData, catsData] = await Promise.all([
+      const [itemsData, catsData, recsData] = await Promise.all([
         fetchShoppingItems(),
         fetchShoppingCategories(),
+        fetchShoppingRecommendations().catch(() => []),
       ])
       setItems(itemsData)
       setCategories(catsData)
+      setRecommendations(recsData)
     } catch {
       setError('No se pudo cargar la lista de compras.')
     } finally {
@@ -97,12 +104,41 @@ export default function ShoppingList() {
   async function handleClearPurchased() {
     try {
       await clearPurchasedItems()
-      showToast('Lista limpiada')
+      showToast('Comprados archivados')
       loadData()
     } catch {
       showToast('Error al limpiar', 'error')
     }
   }
+
+  async function handleAddRecommendation(rec) {
+    try {
+      setAddingRecName(rec.name)
+      await createShoppingItem({
+        name: rec.name,
+        note: null,
+        category_id: rec.category_id || null,
+      })
+      showToast(`${rec.name} agregado`)
+      loadData()
+    } catch {
+      showToast('Error al agregar', 'error')
+    } finally {
+      setAddingRecName(null)
+    }
+  }
+
+  function handleDismissRecommendation(rec) {
+    setDismissedRecs(prev => {
+      const next = new Set(prev)
+      next.add(rec.name.toLowerCase())
+      return next
+    })
+  }
+
+  const visibleRecommendations = recommendations.filter(
+    r => !dismissedRecs.has(r.name.toLowerCase())
+  )
 
   const matchesQuery = useCallback((item) => {
     const q = query.trim().toLowerCase()
@@ -162,6 +198,18 @@ export default function ShoppingList() {
         </div>
         <div className="flex items-center gap-2">
           <Link
+            to="/shopping/history"
+            className="w-9 h-9 rounded-xl flex items-center justify-center transition-all active:scale-95"
+            style={{ background: 'rgba(196,184,166,0.15)', color: 'var(--bark-400)' }}
+            title="Historial de compras"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M3 12a9 9 0 109-9 9.75 9.75 0 00-6.74 2.74L3 8"/>
+              <path d="M3 3v5h5"/>
+              <path d="M12 7v5l3 2"/>
+            </svg>
+          </Link>
+          <Link
             to="/shopping/admin"
             className="w-9 h-9 rounded-xl flex items-center justify-center transition-all active:scale-95"
             style={{ background: 'rgba(196,184,166,0.15)', color: 'var(--bark-400)' }}
@@ -182,6 +230,18 @@ export default function ShoppingList() {
         <div className="rounded-xl p-4 mb-4 font-body text-[13px]" style={{ background: 'rgba(184,90,58,0.06)', color: 'var(--clay-500)', border: '1px solid rgba(184,90,58,0.15)' }}>
           {error}
         </div>
+      )}
+
+      {/* Recommendations from purchase history */}
+      {visibleRecommendations.length > 0 && (
+        <RecommendationsSection
+          recommendations={visibleRecommendations}
+          collapsed={recsCollapsed}
+          onToggleCollapsed={() => setRecsCollapsed(c => !c)}
+          onAdd={handleAddRecommendation}
+          onDismiss={handleDismissRecommendation}
+          addingRecName={addingRecName}
+        />
       )}
 
       {/* Quick add form */}
@@ -376,8 +436,9 @@ export default function ShoppingList() {
                   onClick={handleClearPurchased}
                   className="font-body text-[11px] font-semibold px-2.5 py-1 rounded-lg transition-all active:scale-95"
                   style={{ color: 'var(--clay-500)', background: 'rgba(184,90,58,0.06)' }}
+                  title="Archivar comprados (van al historial)"
                 >
-                  Limpiar lista
+                  Archivar
                 </button>
               </div>
               <div className="flex flex-col gap-2 stagger">
@@ -525,4 +586,109 @@ function formatTimeAgo(dateStr) {
   const days = Math.floor(hours / 24)
   if (days === 1) return 'ayer'
   return `hace ${days}d`
+}
+
+function recommendationStatusLabel(rec) {
+  const d = rec.days_until_next
+  if (d < -1) return `Vencido hace ${Math.abs(d)} dias`
+  if (d <= 0) return 'Toca recomprar'
+  if (d === 1) return 'En 1 dia'
+  return `En ${d} dias`
+}
+
+function RecommendationsSection({
+  recommendations, collapsed, onToggleCollapsed, onAdd, onDismiss, addingRecName,
+}) {
+  return (
+    <div
+      className="mb-5 rounded-2xl overflow-hidden fade-in"
+      style={{
+        background: 'linear-gradient(135deg, rgba(106,153,96,0.06), rgba(196,184,166,0.04))',
+        border: '1px solid rgba(106,153,96,0.18)',
+      }}
+    >
+      <button
+        type="button"
+        onClick={onToggleCollapsed}
+        className="w-full flex items-center justify-between gap-2 px-4 py-3 transition-colors active:scale-[0.995]"
+      >
+        <div className="flex items-center gap-2">
+          <div
+            className="w-7 h-7 rounded-lg flex items-center justify-center"
+            style={{ background: 'rgba(106,153,96,0.18)' }}
+          >
+            <span style={{ fontSize: 14 }}>✨</span>
+          </div>
+          <div className="text-left">
+            <p className="font-body text-[12px] font-bold uppercase tracking-wider" style={{ color: 'var(--moss-600)' }}>
+              Sugeridos para volver a comprar
+            </p>
+            <p className="font-body text-[11px]" style={{ color: 'var(--bark-300)' }}>
+              {recommendations.length} {recommendations.length === 1 ? 'sugerencia' : 'sugerencias'} segun tu historial
+            </p>
+          </div>
+        </div>
+        <svg
+          width="14" height="14" viewBox="0 0 24 24" fill="none"
+          stroke="var(--bark-400)" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"
+          style={{ transform: collapsed ? 'rotate(-90deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }}
+        >
+          <path d="M6 9l6 6 6-6"/>
+        </svg>
+      </button>
+
+      {!collapsed && (
+        <div className="px-3 pb-3 flex flex-col gap-1.5">
+          {recommendations.map((rec, i) => {
+            const isAdding = addingRecName === rec.name
+            return (
+              <div
+                key={`${rec.name}-${i}`}
+                className="flex items-center gap-2 px-3 py-2 rounded-xl"
+                style={{
+                  background: 'var(--surface-card)',
+                  border: '1px solid rgba(196,184,166,0.25)',
+                }}
+              >
+                {rec.category_emoji ? (
+                  <span style={{ fontSize: 16 }}>{rec.category_emoji}</span>
+                ) : (
+                  <span style={{ fontSize: 16 }}>🛒</span>
+                )}
+                <div className="flex-1 min-w-0">
+                  <p className="font-body font-semibold text-[13px] leading-tight truncate" style={{ color: 'var(--bark-700)' }}>
+                    {rec.name}
+                  </p>
+                  <p className="font-body text-[11px]" style={{ color: 'var(--bark-300)' }}>
+                    {recommendationStatusLabel(rec)} · cada ~{rec.avg_interval_days}d · {rec.times_bought}x
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  disabled={isAdding}
+                  onClick={() => onAdd(rec)}
+                  className="px-2.5 py-1.5 rounded-lg font-body font-semibold text-[11px] text-white transition-all active:scale-95 disabled:opacity-50"
+                  style={{ background: 'var(--moss-500)' }}
+                  title="Agregar a la lista"
+                >
+                  {isAdding ? '...' : '+ Agregar'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onDismiss(rec)}
+                  className="w-7 h-7 rounded-lg flex items-center justify-center transition-all active:scale-90"
+                  style={{ color: 'var(--bark-300)' }}
+                  title="Descartar"
+                >
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                    <path d="M18 6L6 18M6 6l12 12"/>
+                  </svg>
+                </button>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
 }

--- a/frontend/src/pages/__tests__/ShoppingList.test.jsx
+++ b/frontend/src/pages/__tests__/ShoppingList.test.jsx
@@ -8,6 +8,7 @@ import ShoppingList from '../ShoppingList'
 vi.mock('../../lib/api', () => ({
   fetchShoppingItems: vi.fn(),
   fetchShoppingCategories: vi.fn(),
+  fetchShoppingRecommendations: vi.fn(),
   createShoppingItem: vi.fn(),
   updateShoppingItem: vi.fn(),
   deleteShoppingItem: vi.fn(),
@@ -17,6 +18,7 @@ vi.mock('../../lib/api', () => ({
 import {
   fetchShoppingItems,
   fetchShoppingCategories,
+  fetchShoppingRecommendations,
   createShoppingItem,
 } from '../../lib/api'
 
@@ -40,6 +42,7 @@ describe('ShoppingList — Smart Tags integration', () => {
     vi.clearAllMocks()
     fetchShoppingItems.mockResolvedValue([])
     fetchShoppingCategories.mockResolvedValue(MOCK_CATEGORIES)
+    fetchShoppingRecommendations.mockResolvedValue([])
     createShoppingItem.mockResolvedValue({ id: 'new-1' })
   })
 
@@ -153,6 +156,70 @@ describe('ShoppingList — Smart Tags integration', () => {
     await user.clear(input)
     await user.type(input, 'lechuga')
     expect(screen.getByText('Frutas y Verduras')).toBeInTheDocument()
+  })
+
+  it('muestra la seccion de sugerencias cuando hay recomendaciones', async () => {
+    fetchShoppingRecommendations.mockResolvedValue([
+      {
+        name: 'Papel higienico',
+        category_id: 'cat-1',
+        category_name: 'Limpieza',
+        category_emoji: '🧻',
+        times_bought: 3,
+        avg_interval_days: 30,
+        last_purchased_at: new Date().toISOString(),
+        predicted_next: new Date().toISOString(),
+        days_until_next: 0,
+      },
+    ])
+    renderShoppingList()
+
+    await waitFor(() => {
+      expect(screen.getByText(/Sugeridos para volver a comprar/i)).toBeInTheDocument()
+    })
+    expect(screen.getByText('Papel higienico')).toBeInTheDocument()
+    expect(screen.getByText(/Toca recomprar/i)).toBeInTheDocument()
+  })
+
+  it('agregar una recomendacion llama a createShoppingItem con su category_id', async () => {
+    const user = userEvent.setup()
+    fetchShoppingRecommendations.mockResolvedValue([
+      {
+        name: 'Detergente',
+        category_id: 'cat-1',
+        category_name: 'Limpieza',
+        category_emoji: '🧹',
+        times_bought: 4,
+        avg_interval_days: 21,
+        last_purchased_at: new Date().toISOString(),
+        predicted_next: new Date().toISOString(),
+        days_until_next: -2,
+      },
+    ])
+    renderShoppingList()
+
+    await waitFor(() => {
+      expect(screen.getByText('Detergente')).toBeInTheDocument()
+    })
+
+    const addBtn = screen.getByRole('button', { name: '+ Agregar' })
+    await user.click(addBtn)
+
+    await waitFor(() => {
+      expect(createShoppingItem).toHaveBeenCalledWith({
+        name: 'Detergente',
+        note: null,
+        category_id: 'cat-1',
+      })
+    })
+  })
+
+  it('no renderiza la seccion de sugerencias cuando no hay recomendaciones', async () => {
+    renderShoppingList()
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Agregar producto...')).toBeInTheDocument()
+    })
+    expect(screen.queryByText(/Sugeridos para volver a comprar/i)).not.toBeInTheDocument()
   })
 
   it('enviar el formulario con sugerencia aceptada envía el category_id correcto', async () => {

--- a/server/index.js
+++ b/server/index.js
@@ -24,6 +24,9 @@ import {
   SHOPPING_CATEGORY_UPDATABLE_COLUMNS,
   SHOPPING_ITEM_UPDATABLE_COLUMNS,
 } from './lib/patch-update.js'
+import { buildRecommendations } from './lib/shopping-recommendations.js'
+
+const SHOPPING_AUTO_ARCHIVE_DAYS = 7
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const UPLOADS_DIR = path.join(__dirname, 'uploads')
@@ -818,11 +821,23 @@ app.delete('/api/shopping-categories/:id', requireAuth, requireHouse, requireRol
 // GET /api/shopping-items
 app.get('/api/shopping-items', requireAuth, requireHouse, async (req, res) => {
   try {
+    // Auto-archivar comprados con mas de SHOPPING_AUTO_ARCHIVE_DAYS dias (lazy).
+    await pool.query(
+      `UPDATE shopping_items
+       SET archived_at = NOW()
+       WHERE organization_id = $1
+         AND is_purchased = true
+         AND archived_at IS NULL
+         AND purchased_at IS NOT NULL
+         AND purchased_at < NOW() - ($2 || ' days')::INTERVAL`,
+      [req.house.id, String(SHOPPING_AUTO_ARCHIVE_DAYS)]
+    )
+
     const { rows } = await pool.query(`
       SELECT si.*, sc.name as category_name, sc.emoji as category_emoji
       FROM shopping_items si
       LEFT JOIN shopping_categories sc ON si.category_id = sc.id
-      WHERE si.organization_id = $1
+      WHERE si.organization_id = $1 AND si.archived_at IS NULL
       ORDER BY si.is_purchased, sc.sort_order NULLS LAST, si.created_at DESC
     `, [req.house.id])
     res.json(rows)
@@ -854,6 +869,18 @@ app.patch('/api/shopping-items/:id', requireAuth, requireHouse, async (req, res)
     delete fields.organization_id
     delete fields.id
 
+    // Auto-sync purchased_at / archived_at cuando cambia is_purchased.
+    // El servidor manda; ignora cualquier purchased_at/archived_at del cliente
+    // en este caso para evitar inconsistencias.
+    if (Object.prototype.hasOwnProperty.call(fields, 'is_purchased')) {
+      if (fields.is_purchased) {
+        fields.purchased_at = new Date()
+      } else {
+        fields.purchased_at = null
+        fields.archived_at = null
+      }
+    }
+
     const built = buildPatchUpdate('shopping_items', fields, SHOPPING_ITEM_UPDATABLE_COLUMNS)
     if (built.error) return res.status(400).json({ error: built.error })
 
@@ -866,10 +893,67 @@ app.patch('/api/shopping-items/:id', requireAuth, requireHouse, async (req, res)
 })
 
 // DELETE /api/shopping-items/clear-purchased
+// Archiva en lugar de borrar: conserva historial para recomendaciones (Fase 2).
 app.delete('/api/shopping-items/clear-purchased', requireAuth, requireHouse, async (req, res) => {
   try {
-    await pool.query('DELETE FROM shopping_items WHERE is_purchased = true AND organization_id = $1', [req.house.id])
+    // Items sin purchased_at (legacy) reciben uno antes de archivar.
+    await pool.query(
+      `UPDATE shopping_items
+       SET purchased_at = COALESCE(purchased_at, NOW()),
+           archived_at = NOW()
+       WHERE is_purchased = true
+         AND archived_at IS NULL
+         AND organization_id = $1`,
+      [req.house.id]
+    )
     res.json({ ok: true })
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// GET /api/shopping-items/history
+// Items archivados, mas recientes primero. Util para vista "Historial".
+app.get('/api/shopping-items/history', requireAuth, requireHouse, async (req, res) => {
+  try {
+    const limit = Math.min(Math.max(parseInt(req.query.limit) || 100, 1), 500)
+    const { rows } = await pool.query(`
+      SELECT si.*, sc.name as category_name, sc.emoji as category_emoji
+      FROM shopping_items si
+      LEFT JOIN shopping_categories sc ON si.category_id = sc.id
+      WHERE si.organization_id = $1 AND si.archived_at IS NOT NULL
+      ORDER BY si.archived_at DESC, si.purchased_at DESC NULLS LAST
+      LIMIT $2
+    `, [req.house.id, limit])
+    res.json(rows)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// GET /api/shopping-items/recommendations
+// Sugiere proximas compras analizando periodicidad del historial archivado.
+app.get('/api/shopping-items/recommendations', requireAuth, requireHouse, async (req, res) => {
+  try {
+    const { rows: archived } = await pool.query(`
+      SELECT si.id, si.name, si.category_id, si.purchased_at,
+             sc.name as category_name, sc.emoji as category_emoji
+      FROM shopping_items si
+      LEFT JOIN shopping_categories sc ON si.category_id = sc.id
+      WHERE si.organization_id = $1
+        AND si.archived_at IS NOT NULL
+        AND si.purchased_at IS NOT NULL
+      ORDER BY si.purchased_at DESC
+    `, [req.house.id])
+
+    const { rows: active } = await pool.query(
+      `SELECT name FROM shopping_items
+       WHERE organization_id = $1 AND archived_at IS NULL`,
+      [req.house.id]
+    )
+
+    const recommendations = buildRecommendations(archived, active)
+    res.json(recommendations)
   } catch (err) {
     res.status(500).json({ error: err.message })
   }
@@ -1281,6 +1365,12 @@ async function migrate() {
     // Shopping categories support
     await addColumnIfMissing('shopping_items', 'category_id', 'UUID REFERENCES shopping_categories(id) ON DELETE SET NULL')
     await pool.query('CREATE INDEX IF NOT EXISTS idx_shopping_items_category ON shopping_items(category_id)')
+
+    // Archivado de compras + historial para recomendaciones (Fase 2)
+    await addColumnIfMissing('shopping_items', 'purchased_at', 'TIMESTAMPTZ')
+    await addColumnIfMissing('shopping_items', 'archived_at', 'TIMESTAMPTZ')
+    await pool.query('CREATE INDEX IF NOT EXISTS idx_shopping_items_archived ON shopping_items(archived_at)')
+    await pool.query('CREATE INDEX IF NOT EXISTS idx_shopping_items_purchased_at ON shopping_items(purchased_at DESC)')
 
     // House member profiles table
     await pool.query(`

--- a/server/lib/patch-update.js
+++ b/server/lib/patch-update.js
@@ -41,6 +41,8 @@ export const SHOPPING_ITEM_UPDATABLE_COLUMNS = new Set([
   'note',
   'is_purchased',
   'category_id',
+  'purchased_at',
+  'archived_at',
 ])
 
 /**

--- a/server/lib/patch-update.test.js
+++ b/server/lib/patch-update.test.js
@@ -129,4 +129,9 @@ describe('whitelists exportados', () => {
     expect(SHOPPING_ITEM_UPDATABLE_COLUMNS.has('organization_id')).toBe(false)
     expect(SHOPPING_ITEM_UPDATABLE_COLUMNS.has('id')).toBe(false)
   })
+
+  it('SHOPPING_ITEM_UPDATABLE_COLUMNS incluye purchased_at y archived_at para archivado', () => {
+    expect(SHOPPING_ITEM_UPDATABLE_COLUMNS.has('purchased_at')).toBe(true)
+    expect(SHOPPING_ITEM_UPDATABLE_COLUMNS.has('archived_at')).toBe(true)
+  })
 })

--- a/server/lib/shopping-recommendations.js
+++ b/server/lib/shopping-recommendations.js
@@ -1,0 +1,97 @@
+// Recomendador de compras por periodicidad detectada.
+// Analiza items archivados (con purchased_at) agrupados por nombre normalizado
+// y predice la proxima compra usando la mediana de los intervalos historicos.
+
+const DEFAULT_INTERVAL_DAYS = 30
+const TOLERANCE_DAYS = 3
+const MIN_TIMES_BOUGHT = 2
+
+export function normalizeName(name) {
+  return (name || '')
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+}
+
+function median(sortedNumbers) {
+  if (sortedNumbers.length === 0) return null
+  const mid = Math.floor(sortedNumbers.length / 2)
+  if (sortedNumbers.length % 2 === 1) return sortedNumbers[mid]
+  return (sortedNumbers[mid - 1] + sortedNumbers[mid]) / 2
+}
+
+/**
+ * buildRecommendations
+ * - archivedItems: filas de shopping_items archivadas (archived_at IS NOT NULL),
+ *   con purchased_at no nulo. Cada fila: { id, name, category_id, category_name,
+ *   category_emoji, purchased_at }.
+ * - activeItems: filas activas en la lista actual (archived_at IS NULL).
+ *   Cada fila: { name }.
+ * - now: instante de referencia (Date), parametrizable para tests deterministas.
+ *
+ * Devuelve un array de sugerencias ordenado por urgencia (mas vencidas primero).
+ */
+export function buildRecommendations(archivedItems, activeItems, now = new Date()) {
+  const groups = new Map()
+  for (const item of archivedItems) {
+    if (!item.purchased_at) continue
+    const key = normalizeName(item.name)
+    if (!key) continue
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key).push(item)
+  }
+
+  const activeNames = new Set(
+    activeItems.map(i => normalizeName(i.name)).filter(Boolean)
+  )
+
+  const nowMs = now.getTime()
+  const recommendations = []
+
+  for (const [key, items] of groups) {
+    if (activeNames.has(key)) continue
+    if (items.length < MIN_TIMES_BOUGHT) continue
+
+    items.sort((a, b) => new Date(b.purchased_at) - new Date(a.purchased_at))
+
+    const intervals = []
+    for (let i = 0; i < items.length - 1; i++) {
+      const diffMs = new Date(items[i].purchased_at) - new Date(items[i + 1].purchased_at)
+      const diffDays = diffMs / (1000 * 60 * 60 * 24)
+      if (diffDays > 0) intervals.push(diffDays)
+    }
+
+    intervals.sort((a, b) => a - b)
+    const intervalDays = intervals.length > 0 ? median(intervals) : DEFAULT_INTERVAL_DAYS
+
+    const last = items[0]
+    const lastMs = new Date(last.purchased_at).getTime()
+    const predictedMs = lastMs + intervalDays * 86400000
+    const daysUntilNext = (predictedMs - nowMs) / 86400000
+
+    if (daysUntilNext > TOLERANCE_DAYS) continue
+
+    recommendations.push({
+      name: last.name,
+      category_id: last.category_id || null,
+      category_name: last.category_name || null,
+      category_emoji: last.category_emoji || null,
+      times_bought: items.length,
+      avg_interval_days: Math.max(1, Math.round(intervalDays)),
+      last_purchased_at: last.purchased_at,
+      predicted_next: new Date(predictedMs).toISOString(),
+      days_until_next: Math.round(daysUntilNext),
+    })
+  }
+
+  recommendations.sort((a, b) => a.days_until_next - b.days_until_next)
+
+  return recommendations
+}
+
+export const RECOMMENDATIONS_CONSTANTS = {
+  DEFAULT_INTERVAL_DAYS,
+  TOLERANCE_DAYS,
+  MIN_TIMES_BOUGHT,
+}

--- a/server/lib/shopping-recommendations.test.js
+++ b/server/lib/shopping-recommendations.test.js
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildRecommendations,
+  normalizeName,
+  RECOMMENDATIONS_CONSTANTS,
+} from './shopping-recommendations.js'
+
+const DAY = 86400000
+
+function daysAgo(now, days) {
+  return new Date(now.getTime() - days * DAY).toISOString()
+}
+
+describe('normalizeName', () => {
+  it('quita acentos, mayusculas y espacios', () => {
+    expect(normalizeName('  Café  ')).toBe('cafe')
+    expect(normalizeName('Jabón Líquido')).toBe('jabon liquido')
+  })
+
+  it('maneja nulls y vacios', () => {
+    expect(normalizeName(null)).toBe('')
+    expect(normalizeName(undefined)).toBe('')
+    expect(normalizeName('')).toBe('')
+  })
+})
+
+describe('buildRecommendations', () => {
+  const now = new Date('2026-05-17T10:00:00Z')
+
+  it('no recomienda items con menos de 2 compras historicas', () => {
+    const archived = [
+      { id: '1', name: 'Papel higienico', purchased_at: daysAgo(now, 35) },
+    ]
+    const result = buildRecommendations(archived, [], now)
+    expect(result).toEqual([])
+  })
+
+  it('recomienda items cuyo intervalo predicho llego a la ventana de tolerancia', () => {
+    const archived = [
+      // 3 compras cada ~30 dias; ultima hace 28 dias -> proxima en 2 dias (dentro de 3 de tolerancia)
+      { id: '1', name: 'Papel higienico', purchased_at: daysAgo(now, 28), category_id: 'c1', category_name: 'Bano', category_emoji: '🧻' },
+      { id: '2', name: 'Papel higienico', purchased_at: daysAgo(now, 58), category_id: 'c1', category_name: 'Bano', category_emoji: '🧻' },
+      { id: '3', name: 'Papel higienico', purchased_at: daysAgo(now, 88), category_id: 'c1', category_name: 'Bano', category_emoji: '🧻' },
+    ]
+    const result = buildRecommendations(archived, [], now)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      name: 'Papel higienico',
+      category_id: 'c1',
+      category_emoji: '🧻',
+      times_bought: 3,
+      avg_interval_days: 30,
+    })
+    expect(result[0].days_until_next).toBeLessThanOrEqual(3)
+  })
+
+  it('no recomienda si todavia falta mas que la tolerancia', () => {
+    const archived = [
+      // ultima hace 5 dias, intervalo 30 -> proxima en 25 dias (fuera de tolerancia)
+      { id: '1', name: 'Cafe', purchased_at: daysAgo(now, 5) },
+      { id: '2', name: 'Cafe', purchased_at: daysAgo(now, 35) },
+    ]
+    const result = buildRecommendations(archived, [], now)
+    expect(result).toEqual([])
+  })
+
+  it('excluye items que ya estan en la lista activa (no archivados)', () => {
+    const archived = [
+      { id: '1', name: 'Leche', purchased_at: daysAgo(now, 8) },
+      { id: '2', name: 'Leche', purchased_at: daysAgo(now, 15) },
+      { id: '3', name: 'Leche', purchased_at: daysAgo(now, 22) },
+    ]
+    const active = [{ name: 'leche' }]
+    const result = buildRecommendations(archived, active, now)
+    expect(result).toEqual([])
+  })
+
+  it('exclusion por nombre activo ignora acentos y mayusculas', () => {
+    const archived = [
+      { id: '1', name: 'Café', purchased_at: daysAgo(now, 8) },
+      { id: '2', name: 'Café', purchased_at: daysAgo(now, 15) },
+      { id: '3', name: 'Café', purchased_at: daysAgo(now, 22) },
+    ]
+    const active = [{ name: '  CAFE  ' }]
+    const result = buildRecommendations(archived, active, now)
+    expect(result).toEqual([])
+  })
+
+  it('agrupa por nombre normalizado (sin acentos / case)', () => {
+    const archived = [
+      { id: '1', name: 'Jabón', purchased_at: daysAgo(now, 25) },
+      { id: '2', name: 'jabon', purchased_at: daysAgo(now, 50) },
+      { id: '3', name: 'JABON', purchased_at: daysAgo(now, 75) },
+    ]
+    const result = buildRecommendations(archived, [], now)
+    expect(result).toHaveLength(1)
+    expect(result[0].times_bought).toBe(3)
+    expect(result[0].name).toBe('Jabón')
+  })
+
+  it('ordena por urgencia ascendente (mas vencidos primero)', () => {
+    const archived = [
+      // A: ultimo hace 45, intervalo 30 -> -15 dias (muy vencido)
+      { id: 'a1', name: 'A', purchased_at: daysAgo(now, 45) },
+      { id: 'a2', name: 'A', purchased_at: daysAgo(now, 75) },
+      // B: ultimo hace 30, intervalo 30 -> 0 dias (exacto hoy)
+      { id: 'b1', name: 'B', purchased_at: daysAgo(now, 30) },
+      { id: 'b2', name: 'B', purchased_at: daysAgo(now, 60) },
+    ]
+    const result = buildRecommendations(archived, [], now)
+    expect(result.map(r => r.name)).toEqual(['A', 'B'])
+    expect(result[0].days_until_next).toBeLessThan(result[1].days_until_next)
+  })
+
+  it('usa mediana, no media, para resistir outliers', () => {
+    const archived = [
+      // Intervalos: 7, 7, 7, 60. Mediana = 7, media = ~20.
+      { id: '1', name: 'Pan', purchased_at: daysAgo(now, 8) },
+      { id: '2', name: 'Pan', purchased_at: daysAgo(now, 15) },
+      { id: '3', name: 'Pan', purchased_at: daysAgo(now, 22) },
+      { id: '4', name: 'Pan', purchased_at: daysAgo(now, 29) },
+      { id: '5', name: 'Pan', purchased_at: daysAgo(now, 89) },
+    ]
+    const result = buildRecommendations(archived, [], now)
+    expect(result).toHaveLength(1)
+    expect(result[0].avg_interval_days).toBe(7)
+  })
+
+  it('ignora archivados sin purchased_at', () => {
+    const archived = [
+      { id: '1', name: 'Sin fecha', purchased_at: null },
+      { id: '2', name: 'Sin fecha', purchased_at: null },
+    ]
+    const result = buildRecommendations(archived, [], now)
+    expect(result).toEqual([])
+  })
+
+  it('expone constantes para tuning', () => {
+    expect(RECOMMENDATIONS_CONSTANTS.MIN_TIMES_BOUGHT).toBe(2)
+    expect(RECOMMENDATIONS_CONSTANTS.TOLERANCE_DAYS).toBe(3)
+  })
+})

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/@better-auth/core": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.5.6.tgz",
-      "integrity": "sha512-Ez9DZdIMFyxHremmoLz1emFPGNQomDC1jqqBPnZ6Ci+6TiGN3R9w/Y03cJn6I8r1ycKgOzeVMZtJ/erOZ27Gsw==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.11.tgz",
+      "integrity": "sha512-LrwidLCV8azdMGjvtwp30nj9tIv1BwI3VhtC0UaGSjQkAVWw4bN42I8qwbxRziPeSQoj+zUVkOpxZzAWBDARtQ==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.39.0",
@@ -92,11 +92,11 @@
         "zod": "^4.3.6"
       },
       "peerDependencies": {
-        "@better-auth/utils": "0.3.1",
+        "@better-auth/utils": "0.4.0",
         "@better-fetch/fetch": "1.1.21",
         "@cloudflare/workers-types": ">=4",
         "@opentelemetry/api": "^1.9.0",
-        "better-call": "1.3.2",
+        "better-call": "1.3.5",
         "jose": "^6.1.0",
         "kysely": "^0.28.5",
         "nanostores": "^1.0.1"
@@ -104,18 +104,21 @@
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
           "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
         }
       }
     },
     "node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.5.6.tgz",
-      "integrity": "sha512-VfFFmaoFw3ug12SiSuIwzrMoHyIVmkMGWm9gZ4sXdYYVX4HboCL4m3fjzOhppcmK5OGatRuU+N1UX6wxCITcXw==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.11.tgz",
+      "integrity": "sha512-4jpkETIGZOHCf7BK4jnu22fdN6jjomH0/HhEzkaWy3+Eppi5PYlHTF/460jrTmA3Xc+Vqwp9t282ymHiEPypGw==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.6",
-        "@better-auth/utils": "^0.3.0",
-        "drizzle-orm": ">=0.41.0"
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0",
+        "drizzle-orm": "^0.45.2"
       },
       "peerDependenciesMeta": {
         "drizzle-orm": {
@@ -124,14 +127,14 @@
       }
     },
     "node_modules/@better-auth/kysely-adapter": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.5.6.tgz",
-      "integrity": "sha512-Fnf+h8WVKtw6lEOmVmiVVzDf3shJtM60AYf9XTnbdCeUd6MxN/KnaJZpkgtYnRs7a+nwtkVB+fg4lGETebGFXQ==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.11.tgz",
+      "integrity": "sha512-/g8M9RfIjdcZDnbstSUvQiINkvdNlCeZr248zwqx2/PVksQI1MhQofbzUn3RnQnbPKp0EPwpX/dR3oudRFenUg==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.6",
-        "@better-auth/utils": "^0.3.0",
-        "kysely": "^0.27.0 || ^0.28.0"
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0",
+        "kysely": "^0.28.17"
       },
       "peerDependenciesMeta": {
         "kysely": {
@@ -140,23 +143,23 @@
       }
     },
     "node_modules/@better-auth/memory-adapter": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.5.6.tgz",
-      "integrity": "sha512-rS7ZsrIl5uvloUgNN0u9LOZJMMXnsZXVdUZ3MrTBKWM2KpoJjzPr9yN3Szyma5+0V7SltnzSGHPkYj2bEzzmlA==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.11.tgz",
+      "integrity": "sha512-hpdfw0BBf8MuzLkIdmbcUZICbY9r/bhLO2RxSnkzT5+/O+0I0u2I8+m0YUP7vNllP/ZCKASHOYgXPLO75Z0f9Q==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.6",
-        "@better-auth/utils": "^0.3.0"
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0"
       }
     },
     "node_modules/@better-auth/mongo-adapter": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.5.6.tgz",
-      "integrity": "sha512-6+M3MS2mor8fTUV3EI1FBLP0cs6QfbN+Ovx9+XxR/GdfKIBoNFzmPEPRbdGt+ft6PvrITsUm+T70+kkHgVSP6w==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.11.tgz",
+      "integrity": "sha512-3Tor8rSv8vSEIMEaV2PFpPEuVhqc1gNoZ6eGvoh3LwExXXuj8madew6ob+H1pH7Aphn3Ar5PQ08AguT8TbwFAA==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.6",
-        "@better-auth/utils": "^0.3.0",
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0",
         "mongodb": "^6.0.0 || ^7.0.0"
       },
       "peerDependenciesMeta": {
@@ -166,13 +169,13 @@
       }
     },
     "node_modules/@better-auth/prisma-adapter": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.5.6.tgz",
-      "integrity": "sha512-UxY9vQJs1Tt+O+T2YQnseDMlWmUSQvFZSBb5YiFRg7zcm+TEzujh4iX2/csA0YiZptLheovIuVWTP9nriewEBA==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.11.tgz",
+      "integrity": "sha512-Pw+7q7zTp+VSci1V+CYMvuxIbAeVMZLe4lRo46LJoAKMHfjFl5T/ycsyFvWs/DkWC7n9gZZzRDEbHp0I5FiKKw==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.6",
-        "@better-auth/utils": "^0.3.0",
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0",
         "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
       },
@@ -186,23 +189,24 @@
       }
     },
     "node_modules/@better-auth/telemetry": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.5.6.tgz",
-      "integrity": "sha512-yXC7NSxnIFlxDkGdpD7KA+J9nqIQAPCJKe77GoaC5bWoe/DALo1MYorZfTgOafS7wrslNtsPT4feV/LJi1ubqQ==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.11.tgz",
+      "integrity": "sha512-hsjDHc8MZbm6/AHeNdtywrWedXevnBjmdvnHTcZub+rTVjOv+Td0roI8USKuC6uUibmrl//2rJfVCsGbopihNA==",
       "license": "MIT",
-      "dependencies": {
-        "@better-auth/utils": "0.3.1",
-        "@better-fetch/fetch": "1.1.21"
-      },
       "peerDependencies": {
-        "@better-auth/core": "1.5.6"
+        "@better-auth/core": "^1.6.11",
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21"
       }
     },
     "node_modules/@better-auth/utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.1.tgz",
-      "integrity": "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg==",
-      "license": "MIT"
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.0.tgz",
+      "integrity": "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1"
+      }
     },
     "node_modules/@better-fetch/fetch": {
       "version": "1.1.21",
@@ -319,15 +323,16 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
-      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -862,26 +867,26 @@
       }
     },
     "node_modules/better-auth": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.5.6.tgz",
-      "integrity": "sha512-QSpJTqaT1XVfWRQe/fm3PgeuwOIlz1nWX/Dx7nsHStJ382bLzmDbQk2u7IT0IJ6wS5SRxfqEE1Ev9TXontgyAQ==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.11.tgz",
+      "integrity": "sha512-Wwt6+q07dwIhsp6XiM7L1qSXVUWBEtNl+eZvwM778CguFqDZFBN9Pt6LtFaHl55t8Z+Zc//5kxcbgDY8/79vFQ==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.5.6",
-        "@better-auth/drizzle-adapter": "1.5.6",
-        "@better-auth/kysely-adapter": "1.5.6",
-        "@better-auth/memory-adapter": "1.5.6",
-        "@better-auth/mongo-adapter": "1.5.6",
-        "@better-auth/prisma-adapter": "1.5.6",
-        "@better-auth/telemetry": "1.5.6",
-        "@better-auth/utils": "0.3.1",
+        "@better-auth/core": "1.6.11",
+        "@better-auth/drizzle-adapter": "1.6.11",
+        "@better-auth/kysely-adapter": "1.6.11",
+        "@better-auth/memory-adapter": "1.6.11",
+        "@better-auth/mongo-adapter": "1.6.11",
+        "@better-auth/prisma-adapter": "1.6.11",
+        "@better-auth/telemetry": "1.6.11",
+        "@better-auth/utils": "0.4.0",
         "@better-fetch/fetch": "1.1.21",
         "@noble/ciphers": "^2.1.1",
         "@noble/hashes": "^2.0.1",
-        "better-call": "1.3.2",
+        "better-call": "1.3.5",
         "defu": "^6.1.4",
         "jose": "^6.1.3",
-        "kysely": "^0.28.12",
+        "kysely": "^0.28.17",
         "nanostores": "^1.1.1",
         "zod": "^4.3.6"
       },
@@ -893,7 +898,7 @@
         "@tanstack/solid-start": "^1.0.0",
         "better-sqlite3": "^12.0.0",
         "drizzle-kit": ">=0.31.4",
-        "drizzle-orm": ">=0.41.0",
+        "drizzle-orm": "^0.45.2",
         "mongodb": "^6.0.0 || ^7.0.0",
         "mysql2": "^3.0.0",
         "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
@@ -967,12 +972,12 @@
       }
     },
     "node_modules/better-call": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.2.tgz",
-      "integrity": "sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.5.tgz",
+      "integrity": "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/utils": "^0.3.1",
+        "@better-auth/utils": "^0.4.0",
         "@better-fetch/fetch": "^1.1.21",
         "rou3": "^0.7.12",
         "set-cookie-parser": "^3.0.1"
@@ -1686,9 +1691,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -1723,9 +1728,9 @@
       }
     },
     "node_modules/kysely": {
-      "version": "0.28.15",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.15.tgz",
-      "integrity": "sha512-r2clcf7HLWvDXaVUEvQymXJY4i3bSOIV3xsL/Upy3ZfSv5HeKsk9tsqbBptLvth5qHEIhxeHTA2jNLyQABkLBA==",
+      "version": "0.28.17",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.17.tgz",
+      "integrity": "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
@@ -2171,9 +2176,9 @@
       }
     },
     "node_modules/nanostores": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.2.0.tgz",
-      "integrity": "sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.3.0.tgz",
+      "integrity": "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==",
       "funding": [
         {
           "type": "github",
@@ -2370,9 +2375,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "devOptional": true,
       "funding": [
         {
@@ -3136,9 +3141,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
Las compras marcadas se archivan automaticamente a los 7 dias en lugar
de borrarse al "Limpiar lista". El historial alimenta un recomendador
que detecta la periodicidad de cada item (mediana de intervalos) y
sugiere proximas compras dentro de una ventana de tolerancia de 3 dias.

- Migracion: purchased_at + archived_at en shopping_items (+ indices)
- GET /api/shopping-items auto-archiva lazy + filtra activos
- PATCH sincroniza purchased_at/archived_at al togglear is_purchased
- GET /api/shopping-items/history y /recommendations nuevos
- DELETE /clear-purchased archiva en vez de borrar
- UI: seccion "Sugeridos" colapsable + pagina /shopping/history
- Tests: 12 nuevos casos (algoritmo + integracion frontend)

Fase 2 (Experiencias Agenticas) — Roadmap CLAUDE.md.