### PR TITLE
fix(ios): evitar zoom automático en inputs en Safari iOS PWA

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,16 @@
 
 ## [Fase 2] — Experiencias Agénticas
 
+### 2026-05-19 — Fix: zoom automático en inputs en iOS Safari (PWA)
+- **Problema** — Safari en iOS aplica zoom automático e irreversible al enfocar cualquier campo editable cuyo `font-size` computado sea menor a 16px. La app usaba `text-[14px]` y `text-[13px]` en inputs/textareas/selects, rompiendo la UX en PWA instalada.
+- **Red de seguridad global** — Regla `@supports (-webkit-touch-callout: none)` en `frontend/src/index.css` que fuerza `font-size: 16px` en `input`/`textarea`/`select`/`[contenteditable=true]` solo en iOS, excluyendo tipos no editables (checkbox, radio, range, file, submit, button, reset). Esto preserva tamaños en desktop si en el futuro alguien introduce un input pequeño por error.
+- **Corrección directa por elemento** — Las 29 instancias con `text-[14px]` o `text-[13px]` se elevaron a `text-[16px]` en `SearchInput`, `TaskForm` (5 campos), `Login` (2), `Register` (4), `HouseSelect` (1), `HouseSettings` (1 invite; el rename ya estaba a 28px), `Plants` (1 select sort, 1 nombre, 1 textarea notas, 1 number frequency), `Products` (1 select sort, 1 nombre, 4 number units/frequency), `ShoppingAdmin` (2), `ShoppingList` (1 nombre, 1 select categoría, 1 nota), `ShoppingHistory` (1 select filtro).
+- **Accesibilidad preservada** — Se confirmó que el meta viewport en `frontend/index.html` mantiene `initial-scale=1.0` sin `maximum-scale` ni `user-scalable=no`, así que el usuario sigue pudiendo hacer pinch-to-zoom.
+- **Jerarquía visual** — La diferencia de 14→16px es mínima (2px) y los inputs ya tenían padding similar; los selects compactos (13→16px) crecen ligeramente pero no rompen la composición. No se usó `transform: scale()` porque la diferencia visual no lo amerita.
+- **Sin contentEditable ni rich-text editors** en el código actual (verificado).
+- **Tests** — 155/155 tests pasan, build de Vite verde (417 kB, 23 kB CSS gzip 5.82 kB).
+- Archivos: `frontend/src/index.css`, `frontend/src/components/SearchInput.jsx`, `frontend/src/components/TaskForm.jsx`, `frontend/src/pages/Login.jsx`, `frontend/src/pages/Register.jsx`, `frontend/src/pages/HouseSelect.jsx`, `frontend/src/pages/HouseSettings.jsx`, `frontend/src/pages/Plants.jsx`, `frontend/src/pages/Products.jsx`, `frontend/src/pages/ShoppingAdmin.jsx`, `frontend/src/pages/ShoppingList.jsx`, `frontend/src/pages/ShoppingHistory.jsx`.
+
 ### 2026-05-17 — Archivado de compras + recomendador por periodicidad
 - **Compras dejan historial en vez de borrarse** — `shopping_items` gana columnas `purchased_at` (se setea automaticamente al marcar `is_purchased=true`, se limpia al desmarcar) y `archived_at` (marca el item como archivado, lo saca de la lista activa). Migracion automatica en `migrate()` + `init.sql` para installs nuevos.
 - **Auto-archivado lazy a los 7 dias** — `GET /api/shopping-items` corre un `UPDATE` previo que archiva los comprados con `purchased_at` mayor a 7 dias. Sin cron, sin worker: aprovecha el trafico normal de la lista. La lista activa filtra por `archived_at IS NULL`.

--- a/frontend/src/components/SearchInput.jsx
+++ b/frontend/src/components/SearchInput.jsx
@@ -11,7 +11,7 @@ export default function SearchInput({ value, onChange, placeholder = 'Buscar...'
         value={value}
         onChange={e => onChange(e.target.value)}
         placeholder={placeholder}
-        className="w-full pl-9 pr-9 py-2.5 rounded-xl font-body text-[14px] focus:outline-none transition-all"
+        className="w-full pl-9 pr-9 py-2.5 rounded-xl font-body text-[16px] focus:outline-none transition-all"
         style={{
           background: 'var(--surface-elevated)',
           border: '1.5px solid rgba(196,184,166,0.3)',

--- a/frontend/src/components/TaskForm.jsx
+++ b/frontend/src/components/TaskForm.jsx
@@ -144,7 +144,7 @@ export default function TaskForm({ task, onSave, onCancel }) {
             value={form.name}
             onChange={e => set('name', e.target.value)}
             placeholder="ej: Barrer la cocina"
-            className="w-full px-3.5 py-2.5 pr-10 rounded-xl font-body text-[14px] focus:outline-none transition-all"
+            className="w-full px-3.5 py-2.5 pr-10 rounded-xl font-body text-[16px] focus:outline-none transition-all"
             style={{
               background: 'var(--surface-elevated)',
               border: '1.5px solid rgba(196,184,166,0.3)',
@@ -166,7 +166,7 @@ export default function TaskForm({ task, onSave, onCancel }) {
           onChange={e => set('description', e.target.value)}
           placeholder="Instrucciones adicionales..."
           rows={2}
-          className="w-full px-3.5 py-2.5 rounded-xl font-body text-[14px] focus:outline-none resize-none transition-all"
+          className="w-full px-3.5 py-2.5 rounded-xl font-body text-[16px] focus:outline-none resize-none transition-all"
           style={{
             background: 'var(--surface-elevated)',
             border: '1.5px solid rgba(196,184,166,0.3)',
@@ -213,7 +213,7 @@ export default function TaskForm({ task, onSave, onCancel }) {
             placeholder={`${FREQUENCY_DEFAULTS[form.frequency_type]}`}
             min={1}
             max={365}
-            className="w-full px-3.5 py-2.5 pr-10 rounded-xl font-body text-[14px] focus:outline-none"
+            className="w-full px-3.5 py-2.5 pr-10 rounded-xl font-body text-[16px] focus:outline-none"
             style={{
               background: 'var(--surface-elevated)',
               border: `1.5px solid ${frequencyState(form.frequency_value) === 'invalid' ? 'var(--clay-500)' : 'rgba(196,184,166,0.3)'}`,
@@ -242,7 +242,7 @@ export default function TaskForm({ task, onSave, onCancel }) {
           value={form.product_name}
           onChange={e => set('product_name', e.target.value)}
           placeholder="ej: Fabuloso Lavanda"
-          className="w-full px-3.5 py-2.5 rounded-xl font-body text-[14px] focus:outline-none transition-all mb-2"
+          className="w-full px-3.5 py-2.5 rounded-xl font-body text-[16px] focus:outline-none transition-all mb-2"
           style={{
             background: 'var(--surface-elevated)',
             border: '1.5px solid rgba(196,184,166,0.3)',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -41,6 +41,18 @@
     background-color: var(--surface-base);
     overflow-x: hidden;
   }
+
+  /* iOS Safari aplica zoom automatico irreversible a campos editables
+     cuyo font-size computado es menor a 16px. Esta regla defensiva
+     garantiza el minimo en iOS sin afectar otras plataformas. */
+  @supports (-webkit-touch-callout: none) {
+    input:not([type='checkbox']):not([type='radio']):not([type='range']):not([type='file']):not([type='submit']):not([type='button']):not([type='reset']),
+    textarea,
+    select,
+    [contenteditable='true'] {
+      font-size: 16px;
+    }
+  }
 }
 
 @layer components {

--- a/frontend/src/pages/HouseSelect.jsx
+++ b/frontend/src/pages/HouseSelect.jsx
@@ -399,7 +399,7 @@ function CreateHouseModal({ onSave, onClose }) {
                   placeholder="Ej: Mi Hogar, Casa de la playa..."
                   maxLength={50}
                   required
-                  className="w-full px-3.5 py-2.5 rounded-xl font-body text-[14px] outline-none transition-all"
+                  className="w-full px-3.5 py-2.5 rounded-xl font-body text-[16px] outline-none transition-all"
                   style={{ background: 'var(--surface-elevated)', border: '1.5px solid rgba(196,184,166,0.3)', color: 'var(--bark-700)' }}
                   onFocus={e => e.target.style.borderColor = 'var(--moss-400)'}
                   onBlur={e => e.target.style.borderColor = 'rgba(196,184,166,0.3)'}

--- a/frontend/src/pages/HouseSettings.jsx
+++ b/frontend/src/pages/HouseSettings.jsx
@@ -471,7 +471,7 @@ export default function HouseSettings() {
                 onChange={e => setInviteEmail(e.target.value)}
                 placeholder="email@ejemplo.com"
                 required
-                className="w-full px-3.5 py-2.5 rounded-xl font-body text-[14px] outline-none transition-all"
+                className="w-full px-3.5 py-2.5 rounded-xl font-body text-[16px] outline-none transition-all"
                 style={{ background: 'var(--surface-elevated)', border: '1.5px solid rgba(196,184,166,0.3)', color: 'var(--bark-700)' }}
                 onFocus={e => e.target.style.borderColor = 'var(--moss-400)'}
                 onBlur={e => e.target.style.borderColor = 'rgba(196,184,166,0.3)'}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -67,7 +67,7 @@ export default function Login() {
               onChange={e => setEmail(e.target.value)}
               placeholder="tu@email.com"
               required
-              className="w-full px-3.5 py-2.5 rounded-xl font-body text-[14px] outline-none transition-all"
+              className="w-full px-3.5 py-2.5 rounded-xl font-body text-[16px] outline-none transition-all"
               style={{ background: 'var(--surface-elevated)', border: '1.5px solid rgba(196,184,166,0.3)', color: 'var(--bark-700)' }}
               onFocus={e => e.target.style.borderColor = 'var(--moss-400)'}
               onBlur={e => e.target.style.borderColor = 'rgba(196,184,166,0.3)'}
@@ -85,7 +85,7 @@ export default function Login() {
               onChange={e => setPassword(e.target.value)}
               placeholder="Tu contrasena"
               required
-              className="w-full px-3.5 py-2.5 rounded-xl font-body text-[14px] outline-none transition-all"
+              className="w-full px-3.5 py-2.5 rounded-xl font-body text-[16px] outline-none transition-all"
               style={{ background: 'var(--surface-elevated)', border: '1.5px solid rgba(196,184,166,0.3)', color: 'var(--bark-700)' }}
               onFocus={e => e.target.style.borderColor = 'var(--moss-400)'}
               onBlur={e => e.target.style.borderColor = 'rgba(196,184,166,0.3)'}

--- a/frontend/src/pages/Plants.jsx
+++ b/frontend/src/pages/Plants.jsx
@@ -213,7 +213,7 @@ export default function Plants() {
               value={sort}
               onChange={e => setSort(e.target.value)}
               aria-label="Ordenar"
-              className="appearance-none pl-8 pr-7 py-2.5 rounded-xl font-body text-[13px] font-semibold outline-none transition-all cursor-pointer"
+              className="appearance-none pl-8 pr-7 py-2.5 rounded-xl font-body text-[16px] font-semibold outline-none transition-all cursor-pointer"
               style={{
                 background: 'var(--surface-elevated)',
                 border: '1.5px solid rgba(196,184,166,0.3)',
@@ -467,7 +467,7 @@ function PlantForm({ plant, onSave, onCancel }) {
           onChange={e => setName(e.target.value)}
           placeholder="Ej: Monstera del salon"
           required
-          className="w-full px-3.5 py-2.5 rounded-xl font-body text-[14px] outline-none transition-all"
+          className="w-full px-3.5 py-2.5 rounded-xl font-body text-[16px] outline-none transition-all"
           style={{
             background: 'var(--surface-elevated)',
             border: '1.5px solid rgba(196,184,166,0.3)',
@@ -487,7 +487,7 @@ function PlantForm({ plant, onSave, onCancel }) {
           onChange={e => setNotes(e.target.value)}
           placeholder="Ubicacion, especie, cuidados especiales..."
           rows={2}
-          className="w-full px-3.5 py-2.5 rounded-xl font-body text-[14px] outline-none transition-all resize-none"
+          className="w-full px-3.5 py-2.5 rounded-xl font-body text-[16px] outline-none transition-all resize-none"
           style={{
             background: 'var(--surface-elevated)',
             border: '1.5px solid rgba(196,184,166,0.3)',
@@ -526,7 +526,7 @@ function PlantForm({ plant, onSave, onCancel }) {
             max="365"
             value={frequencyDays}
             onChange={e => setFrequencyDays(e.target.value)}
-            className="w-20 px-3 py-2 rounded-xl font-body text-[14px] text-center outline-none"
+            className="w-20 px-3 py-2 rounded-xl font-body text-[16px] text-center outline-none"
             style={{
               background: 'var(--surface-elevated)',
               border: '1.5px solid rgba(196,184,166,0.3)',

--- a/frontend/src/pages/Products.jsx
+++ b/frontend/src/pages/Products.jsx
@@ -319,7 +319,7 @@ export default function Products() {
               value={sort}
               onChange={e => setSort(e.target.value)}
               aria-label="Ordenar"
-              className="appearance-none pl-8 pr-7 py-2.5 rounded-xl font-body text-[13px] font-semibold outline-none transition-all cursor-pointer"
+              className="appearance-none pl-8 pr-7 py-2.5 rounded-xl font-body text-[16px] font-semibold outline-none transition-all cursor-pointer"
               style={{
                 background: 'var(--surface-elevated)',
                 border: '1.5px solid rgba(196,184,166,0.3)',
@@ -654,7 +654,7 @@ function ProductForm({ product, onSave, onCancel }) {
           onChange={e => setName(e.target.value)}
           placeholder="Ej: Jabon lavavajillas"
           required
-          className="w-full px-3.5 py-2.5 rounded-xl font-body text-[14px] outline-none transition-all"
+          className="w-full px-3.5 py-2.5 rounded-xl font-body text-[16px] outline-none transition-all"
           style={{
             background: 'var(--surface-elevated)',
             border: '1.5px solid rgba(196,184,166,0.3)',
@@ -718,7 +718,7 @@ function ProductForm({ product, onSave, onCancel }) {
             max="365"
             value={frequencyDays}
             onChange={e => setFrequencyDays(e.target.value)}
-            className="w-20 px-3 py-2 rounded-xl font-body text-[14px] text-center outline-none"
+            className="w-20 px-3 py-2 rounded-xl font-body text-[16px] text-center outline-none"
             style={{
               background: 'var(--surface-elevated)',
               border: '1.5px solid rgba(196,184,166,0.3)',
@@ -741,7 +741,7 @@ function ProductForm({ product, onSave, onCancel }) {
             max="99"
             value={units}
             onChange={e => setUnits(e.target.value)}
-            className="w-20 px-3 py-2 rounded-xl font-body text-[14px] text-center outline-none"
+            className="w-20 px-3 py-2 rounded-xl font-body text-[16px] text-center outline-none"
             style={{
               background: 'var(--surface-elevated)',
               border: '1.5px solid rgba(196,184,166,0.3)',
@@ -844,7 +844,7 @@ function EarlyOutOfStockModal({ product, actualDays, onAdjustUnits, onAdjustFreq
               max="99"
               value={newUnits}
               onChange={e => setNewUnits(e.target.value)}
-              className="w-20 px-3 py-2 rounded-xl font-body text-[14px] text-center outline-none"
+              className="w-20 px-3 py-2 rounded-xl font-body text-[16px] text-center outline-none"
               style={{ background: 'var(--surface-card)', border: '1.5px solid rgba(196,184,166,0.3)', color: 'var(--bark-700)' }}
             />
             <span className="font-body text-[13px]" style={{ color: 'var(--bark-300)' }}>unidades</span>
@@ -877,7 +877,7 @@ function EarlyOutOfStockModal({ product, actualDays, onAdjustUnits, onAdjustFreq
               max="365"
               value={newFrequency}
               onChange={e => setNewFrequency(e.target.value)}
-              className="w-20 px-3 py-2 rounded-xl font-body text-[14px] text-center outline-none"
+              className="w-20 px-3 py-2 rounded-xl font-body text-[16px] text-center outline-none"
               style={{ background: 'var(--surface-card)', border: '1.5px solid rgba(196,184,166,0.3)', color: 'var(--bark-700)' }}
             />
             <span className="font-body text-[13px]" style={{ color: 'var(--bark-300)' }}>dias</span>

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -81,7 +81,7 @@ export default function Register() {
               placeholder="Tu nombre"
               required
               maxLength={50}
-              className="w-full px-3.5 py-2.5 rounded-xl font-body text-[14px] outline-none transition-all"
+              className="w-full px-3.5 py-2.5 rounded-xl font-body text-[16px] outline-none transition-all"
               style={{ background: 'var(--surface-elevated)', border: '1.5px solid rgba(196,184,166,0.3)', color: 'var(--bark-700)' }}
               onFocus={e => e.target.style.borderColor = 'var(--moss-400)'}
               onBlur={e => e.target.style.borderColor = 'rgba(196,184,166,0.3)'}
@@ -99,7 +99,7 @@ export default function Register() {
               onChange={e => setEmail(e.target.value)}
               placeholder="tu@email.com"
               required
-              className="w-full px-3.5 py-2.5 rounded-xl font-body text-[14px] outline-none transition-all"
+              className="w-full px-3.5 py-2.5 rounded-xl font-body text-[16px] outline-none transition-all"
               style={{ background: 'var(--surface-elevated)', border: '1.5px solid rgba(196,184,166,0.3)', color: 'var(--bark-700)' }}
               onFocus={e => e.target.style.borderColor = 'var(--moss-400)'}
               onBlur={e => e.target.style.borderColor = 'rgba(196,184,166,0.3)'}
@@ -117,7 +117,7 @@ export default function Register() {
               placeholder="Minimo 8 caracteres"
               required
               minLength={8}
-              className="w-full px-3.5 py-2.5 rounded-xl font-body text-[14px] outline-none transition-all"
+              className="w-full px-3.5 py-2.5 rounded-xl font-body text-[16px] outline-none transition-all"
               style={{ background: 'var(--surface-elevated)', border: '1.5px solid rgba(196,184,166,0.3)', color: 'var(--bark-700)' }}
               onFocus={e => e.target.style.borderColor = 'var(--moss-400)'}
               onBlur={e => e.target.style.borderColor = 'rgba(196,184,166,0.3)'}
@@ -135,7 +135,7 @@ export default function Register() {
               placeholder="Repite tu contrasena"
               required
               minLength={8}
-              className="w-full px-3.5 py-2.5 rounded-xl font-body text-[14px] outline-none transition-all"
+              className="w-full px-3.5 py-2.5 rounded-xl font-body text-[16px] outline-none transition-all"
               style={{ background: 'var(--surface-elevated)', border: '1.5px solid rgba(196,184,166,0.3)', color: 'var(--bark-700)' }}
               onFocus={e => e.target.style.borderColor = 'var(--moss-400)'}
               onBlur={e => e.target.style.borderColor = 'rgba(196,184,166,0.3)'}

--- a/frontend/src/pages/ShoppingAdmin.jsx
+++ b/frontend/src/pages/ShoppingAdmin.jsx
@@ -150,7 +150,7 @@ export default function ShoppingAdmin() {
             value={newName}
             onChange={e => setNewName(e.target.value)}
             placeholder="Nombre de categoria (ej: Almacen, Carniceria...)"
-            className="flex-1 px-3.5 py-2.5 rounded-xl font-body text-[14px] outline-none transition-all"
+            className="flex-1 px-3.5 py-2.5 rounded-xl font-body text-[16px] outline-none transition-all"
             style={{
               background: 'var(--surface-card)',
               border: '1.5px solid rgba(196,184,166,0.3)',
@@ -200,7 +200,7 @@ export default function ShoppingAdmin() {
                     type="text"
                     value={editName}
                     onChange={e => setEditName(e.target.value)}
-                    className="flex-1 px-3 py-1.5 rounded-lg font-body text-[14px] outline-none"
+                    className="flex-1 px-3 py-1.5 rounded-lg font-body text-[16px] outline-none"
                     style={{
                       background: 'var(--surface-base)',
                       border: '1.5px solid var(--moss-400)',

--- a/frontend/src/pages/ShoppingHistory.jsx
+++ b/frontend/src/pages/ShoppingHistory.jsx
@@ -106,7 +106,7 @@ export default function ShoppingHistory() {
               <select
                 value={categoryFilter}
                 onChange={e => setCategoryFilter(e.target.value)}
-                className="px-3 py-2 rounded-xl font-body text-[13px] outline-none transition-all appearance-none cursor-pointer"
+                className="px-3 py-2 rounded-xl font-body text-[16px] outline-none transition-all appearance-none cursor-pointer"
                 style={{
                   background: 'var(--surface-card)',
                   border: '1.5px solid rgba(196,184,166,0.3)',

--- a/frontend/src/pages/ShoppingList.jsx
+++ b/frontend/src/pages/ShoppingList.jsx
@@ -253,7 +253,7 @@ export default function ShoppingList() {
               value={newName}
               onChange={e => setNewName(e.target.value)}
               placeholder="Agregar producto..."
-              className="w-full px-3.5 py-2.5 rounded-xl font-body text-[14px] outline-none transition-all pr-10"
+              className="w-full px-3.5 py-2.5 rounded-xl font-body text-[16px] outline-none transition-all pr-10"
               style={{
                 background: 'var(--surface-card)',
                 border: '1.5px solid rgba(196,184,166,0.3)',
@@ -327,7 +327,7 @@ export default function ShoppingList() {
             <select
               value={newCategoryId}
               onChange={e => setNewCategoryId(e.target.value)}
-              className="px-3 py-2 rounded-xl font-body text-[13px] outline-none transition-all appearance-none cursor-pointer"
+              className="px-3 py-2 rounded-xl font-body text-[16px] outline-none transition-all appearance-none cursor-pointer"
               style={{
                 background: 'var(--surface-card)',
                 border: '1.5px solid rgba(196,184,166,0.3)',
@@ -348,7 +348,7 @@ export default function ShoppingList() {
               value={newNote}
               onChange={e => setNewNote(e.target.value)}
               placeholder="Nota (ej: marca, cantidad...)"
-              className="flex-1 px-3.5 py-2 rounded-xl font-body text-[13px] outline-none transition-all"
+              className="flex-1 px-3.5 py-2 rounded-xl font-body text-[16px] outline-none transition-all"
               style={{
                 background: 'var(--surface-card)',
                 border: '1.5px solid rgba(196,184,166,0.3)',


### PR DESCRIPTION
Safari iOS hace zoom irreversible en inputs cuyo font-size computado
es menor a 16px. Los inputs, textareas y selects de la app usaban
text-[14px] y text-[13px], rompiendo la UX en PWA instalada.

- Se eleva a text-[16px] todos los elementos editables (29 instancias)
- Se añade red de seguridad global en index.css con
  @supports (-webkit-touch-callout: none) para futuros descuidos
- Meta viewport intacto (sigue permitiendo pinch-to-zoom)