### PR TITLE
fix(pwa): forzar actualización de caché en PWA iOS tras deploy

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,14 @@
 
 ## [Fase 2] — Experiencias Agénticas
 
+### 2026-05-20 — Fix: la PWA en iOS no recibía actualizaciones (caché)
+- **Problema** — Tras mergear el fix de zoom en inputs, la PWA instalada en iOS seguía mostrando la versión vieja. Causa raíz: el `nginx.conf` no enviaba `Cache-Control` para `index.html` ni `sw.js`, así que iOS los cacheaba indefinidamente y nunca pedía los assets hasheados nuevos. Sumado a un `CACHE_NAME` fijo en el Service Worker, la app quedaba pegada en el build anterior.
+- **`nginx.conf` — política de caché correcta** — `/assets/*` (archivos con hash de Vite) se sirven `immutable` con `expires 1y`; `index.html` y todas las rutas SPA se sirven con `Cache-Control: no-cache`; `sw.js` con `no-cache` para que el navegador detecte cada nuevo deploy.
+- **`sw.js` — versionado de caché** — `CACHE_NAME` sube de `v1` a `v2`. Al cambiar los bytes del SW, el navegador lo reinstala y el handler `activate` purga el caché viejo (`v1`); con `skipWaiting()` + `clients.claim()` ya existentes, el SW nuevo toma control de inmediato.
+- **`index.html` — auto-recarga al actualizar** — listener `controllerchange` con guard `refreshing` recarga la página una sola vez cuando un nuevo Service Worker toma control, así el usuario ve el build nuevo sin tener que cerrar la PWA manualmente.
+- **Acción manual única requerida** — Los dispositivos que ya tienen el SW viejo cacheado necesitan forzar una limpieza una vez (cerrar la PWA del todo y reabrir con red, o desinstalar/reinstalar). A partir de este deploy, las futuras actualizaciones llegan solas.
+- Archivos: `frontend/nginx.conf`, `frontend/public/sw.js`, `frontend/index.html`.
+
 ### 2026-05-19 — Fix: zoom automático en inputs en iOS Safari (PWA)
 - **Problema** — Safari en iOS aplica zoom automático e irreversible al enfocar cualquier campo editable cuyo `font-size` computado sea menor a 16px. La app usaba `text-[14px]` y `text-[13px]` en inputs/textareas/selects, rompiendo la UX en PWA instalada.
 - **Red de seguridad global** — Regla `@supports (-webkit-touch-callout: none)` en `frontend/src/index.css` que fuerza `font-size: 16px` en `input`/`textarea`/`select`/`[contenteditable=true]` solo en iOS, excluyendo tipos no editables (checkbox, radio, range, file, submit, button, reset). Esto preserva tamaños en desktop si en el futuro alguien introduce un input pequeño por error.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -27,6 +27,12 @@
         window.addEventListener('load', () => {
           navigator.serviceWorker.register('./sw.js')
         })
+        let refreshing = false
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          if (refreshing) return
+          refreshing = true
+          window.location.reload()
+        })
       }
     </script>
   </body>

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -13,7 +13,21 @@ server {
         proxy_cookie_path / /;
     }
 
+    # Assets con hash en el nombre (Vite): inmutables, cache largo.
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # El service worker debe revalidarse siempre para detectar nuevos deploys.
+    location = /sw.js {
+        add_header Cache-Control "no-cache";
+    }
+
+    # HTML y rutas SPA: nunca servir una version cacheada, asi las
+    # referencias a los assets hasheados siempre apuntan al ultimo build.
     location / {
         try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache";
     }
 }

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'casa-limpia-v1'
+const CACHE_NAME = 'casa-limpia-v2'
 
 const PRECACHE_URLS = [
   './',


### PR DESCRIPTION
## Summary

La PWA instalada en iOS seguía mostrando el build viejo tras mergear el fix de zoom (#28). El código del fix de inputs es correcto y ya está en `main`; el problema era de **caché de la PWA**.

- **`nginx.conf`** — `/assets/*` (archivos con hash de Vite) se sirven `immutable` con `expires 1y`; `index.html` y rutas SPA con `Cache-Control: no-cache`; `sw.js` con `no-cache` para que el navegador detecte cada nuevo deploy. Antes nginx no enviaba ningún `Cache-Control`, así que iOS cacheaba el HTML/SW y nunca pedía los assets nuevos.
- **`public/sw.js`** — `CACHE_NAME` sube de `v1` a `v2`. Al cambiar los bytes del SW, el navegador lo reinstala y el handler `activate` purga el caché viejo; con `skipWaiting()` + `clients.claim()` existentes, el SW nuevo toma control de inmediato.
- **`index.html`** — listener `controllerchange` (con guard) que recarga la página una sola vez cuando un nuevo Service Worker toma control, para aplicar el build nuevo sin cerrar la PWA manualmente.

## Nota de despliegue

- Tras mergear, desplegar: `docker compose pull web && docker compose up -d web`.
- Los dispositivos que ya tienen el SW `v1` cacheado requieren una limpieza manual única (borrar datos del sitio en Safari o reinstalar la PWA). A partir de este deploy las futuras actualizaciones llegan solas.

## Test plan

- [x] `npm test` — server + frontend (pre-commit hook)
- [x] `npm run build` — Vite verde; `dist/sw.js` contiene `casa-limpia-v2`; `dist/index.html` contiene el listener `controllerchange`
- [x] CHANGELOG actualizado (Fase 2, 2026-05-20)
- [ ] QA manual: tras deploy, abrir PWA en iOS y confirmar que el zoom desaparece sin reinstalar (en dispositivos nuevos) y que las actualizaciones futuras se aplican solas

## Roadmap

Fase 2 — Experiencias Agénticas (hardening de actualizaciones de la PWA).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FVNa4shyhqvdJh4kaQrwGU)_