### PR TITLE
fix: hacer accesible Tareas al elegir otra pantalla de inicio

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,13 @@
 
 ## [Fase 2] — Experiencias Agénticas
 
+### 2026-05-20 — Fix: Tareas inaccesible al elegir otra pantalla de inicio
+- **Problema** — Al configurar una pantalla de inicio distinta a `Tareas` (p. ej. `Compras`), Tareas quedaba inalcanzable. Causa raíz: la página de Tareas (`Home`) solo existía en la ruta `/`, que es el despachador `HomeRedirect`. Cuando la preferencia no era `tasks`, entrar a `/` redirigía a la pantalla configurada, y como el enlace "Tareas" del menú apuntaba a `/`, siempre terminaba redirigiendo fuera de Tareas.
+- **Solución** — Tareas gana su propia ruta estable `/tasks` (en `main.jsx`), independiente del despachador. `HomeRedirect` queda como dispatcher puro: siempre hace `<Navigate replace>` a la ruta de la preferencia. El enlace "Tareas" del menú (`Layout.jsx`) ahora apunta a `/tasks`, y `homeScreen.js` mapea `tasks → /tasks`.
+- **Sin loops ni cambios de backend** — `getStoredHomeScreen` ya garantiza un valor válido, y todas las pantallas mapean a rutas propias (ninguna a `/`), así que no hay auto-redirección. El logo sigue apuntando a `/` (lleva a la pantalla de inicio configurada).
+- **Tests** — frontend 160/160, build de Vite verde.
+- Archivos: `frontend/src/main.jsx`, `frontend/src/components/Layout.jsx`, `frontend/src/lib/homeScreen.js`.
+
 ### 2026-05-20 — Edición inline de ítems en la lista de compras
 - **Editar ítems ya agregados** — cada ítem de `/shopping` (pendiente o comprado) gana un botón de lápiz que lo convierte en un formulario inline editable, replicando el patrón que ya existía en `ShoppingAdmin`. Resuelve el caso de "agregar/cambiar la categoría después de creado", además de corregir nombre y nota.
 - **Campos editables** — nombre, categoría (select con las categorías de la casa + "Sin categoria") y nota. Guardar con Enter, cancelar con Escape o el botón. No permite guardar con el nombre vacío.

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -71,7 +71,7 @@ export default function Layout() {
   }
 
   const navItems = [
-    { to: '/', label: 'Tareas', end: true, activeColor: 'var(--moss-500)' },
+    { to: '/tasks', label: 'Tareas', end: true, activeColor: 'var(--moss-500)' },
     { to: '/stats', label: 'Stats', activeColor: 'var(--moss-500)' },
     { to: '/products', label: 'Productos', activeColor: 'var(--clay-500)' },
     { to: '/plants', label: 'Plantas', activeColor: 'var(--moss-500)' },

--- a/frontend/src/lib/homeScreen.js
+++ b/frontend/src/lib/homeScreen.js
@@ -1,5 +1,5 @@
 export const HOME_SCREENS = [
-  { value: 'tasks',    label: 'Tareas',    route: '/' },
+  { value: 'tasks',    label: 'Tareas',    route: '/tasks' },
   { value: 'shopping', label: 'Compras',   route: '/shopping' },
   { value: 'products', label: 'Productos', route: '/products' },
   { value: 'stats',    label: 'Stats',     route: '/stats' },

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -18,7 +18,7 @@ import Stats from './pages/Stats'
 import Layout from './components/Layout'
 import { authClient } from './lib/auth'
 import { getActiveHouse } from './lib/house'
-import { getStoredHomeScreen, routeForHomeScreen, DEFAULT_HOME_SCREEN } from './lib/homeScreen'
+import { getStoredHomeScreen, routeForHomeScreen } from './lib/homeScreen'
 
 function RequireAuth({ children }) {
   const { data: session, isPending } = authClient.useSession()
@@ -47,10 +47,7 @@ function RequireHouse({ children }) {
 function HomeRedirect() {
   const house = getActiveHouse()
   const preferred = getStoredHomeScreen(house?.id)
-  if (preferred && preferred !== DEFAULT_HOME_SCREEN) {
-    return <Navigate to={routeForHomeScreen(preferred)} replace />
-  }
-  return <Home />
+  return <Navigate to={routeForHomeScreen(preferred)} replace />
 }
 
 ReactDOM.createRoot(document.getElementById('root')).render(
@@ -67,6 +64,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
         {/* Authenticated + house selected */}
         <Route element={<RequireAuth><RequireHouse><Layout /></RequireHouse></RequireAuth>}>
           <Route path="/" element={<HomeRedirect />} />
+          <Route path="/tasks" element={<Home />} />
           <Route path="/products" element={<Products />} />
           <Route path="/plants" element={<Plants />} />
           <Route path="/shopping" element={<ShoppingList />} />


### PR DESCRIPTION
La pagina de Tareas solo existia en la ruta '/', que es el despachador
HomeRedirect. Al configurar otra pantalla de inicio (p. ej. Compras),
entrar a '/' redirigia fuera y Tareas quedaba inalcanzable.

Se agrega una ruta dedicada '/tasks' para Tareas, independiente del
despachador; HomeRedirect queda como dispatcher puro y el enlace del
menu apunta a '/tasks'.

https://claude.ai/code/session_01UVnbq35jDtbGH5nf2jr6Kv