### PR TITLE
feat: tareas efímeras de una sola vez

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS tasks (
     id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,
     name        TEXT NOT NULL,
     description TEXT,
-    frequency_type  TEXT NOT NULL CHECK (frequency_type IN ('daily', 'weekly', 'biweekly', 'monthly')),
+    frequency_type  TEXT NOT NULL CHECK (frequency_type IN ('daily', 'weekly', 'biweekly', 'monthly', 'once')),
     frequency_value INTEGER NOT NULL DEFAULT 1,
     is_active   BOOLEAN NOT NULL DEFAULT true,
     product_name  TEXT,
@@ -13,6 +13,11 @@ CREATE TABLE IF NOT EXISTS tasks (
 );
 
 ALTER TABLE tasks ADD COLUMN IF NOT EXISTS last_reset_at TIMESTAMPTZ;
+
+-- Permite tareas efimeras de una sola vez ('once'): se desactivan al cumplirse.
+ALTER TABLE tasks DROP CONSTRAINT IF EXISTS tasks_frequency_type_check;
+ALTER TABLE tasks ADD CONSTRAINT tasks_frequency_type_check
+    CHECK (frequency_type IN ('daily', 'weekly', 'biweekly', 'monthly', 'once'));
 
 CREATE TABLE IF NOT EXISTS completions (
     id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,15 @@
 
 ## [Fase 2] — Experiencias Agénticas
 
+### 2026-05-24 — Tareas efímeras (de una sola vez)
+- **Nueva frecuencia "Única vez"** — además de las recurrentes (Diario/Semanal/Quincenal/Mensual), una tarea puede marcarse como efímera. Cubre el caso de pendientes puntuales ("colgar el cuadro", "llamar al técnico") que no tiene sentido que reaparezcan en la lista.
+- **Auto-desactivación al cumplirse** — al registrar la completación de una tarea `once`, el backend hace `UPDATE tasks SET is_active = false` en el mismo request. Desaparece de pendientes sin pasos extra. Queda inactiva (no se borra): conserva su historial y se puede ver/reactivar desde el panel de Admin (filtro de inactivas).
+- **No recurre** — el query `GET /api/tasks/pending` excluye el cálculo de intervalo para `frequency_type = 'once'` (`AND t.frequency_type <> 'once'`). Una tarea de una sola vez solo vuelve a aparecer si nunca se completó o si se usa "marcar pendiente" (reset) explícito.
+- **Backend** — `db/init.sql`: el `CHECK` de `frequency_type` ahora admite `'once'`, con migración incremental para BDs existentes (`DROP CONSTRAINT IF EXISTS` + `ADD CONSTRAINT`). `server/index.js`: guard de recurrencia en pendientes, validación de onboarding ampliada y auto-desactivación en `POST /api/completions` (reutilizando una sola consulta para nombre y frecuencia).
+- **Frontend** — `lib/tasks.js`: nueva etiqueta/`default` `once`, `isTaskPending` y `frequencyLabel` tratan el caso. `TaskForm.jsx`: botón "Única vez" separado de la grilla recurrente y el campo "Días" se oculta cuando no aplica. `Admin.jsx`: ícono propio para la frecuencia efímera.
+- **Tests** — frontend 163/163 (4 casos nuevos en `tasks.test.js`), backend 70/70, build de Vite verde.
+- Archivos: `db/init.sql`, `server/index.js`, `frontend/src/lib/tasks.js`, `frontend/src/components/TaskForm.jsx`, `frontend/src/pages/Admin.jsx`, `frontend/src/lib/__tests__/tasks.test.js`.
+
 ### 2026-05-20 — Fix: Tareas inaccesible al elegir otra pantalla de inicio
 - **Problema** — Al configurar una pantalla de inicio distinta a `Tareas` (p. ej. `Compras`), Tareas quedaba inalcanzable. Causa raíz: la página de Tareas (`Home`) solo existía en la ruta `/`, que es el despachador `HomeRedirect`. Cuando la preferencia no era `tasks`, entrar a `/` redirigía a la pantalla configurada, y como el enlace "Tareas" del menú apuntaba a `/`, siempre terminaba redirigiendo fuera de Tareas.
 - **Solución** — Tareas gana su propia ruta estable `/tasks` (en `main.jsx`), independiente del despachador. `HomeRedirect` queda como dispatcher puro: siempre hace `<Navigate replace>` a la ruta de la preferencia. El enlace "Tareas" del menú (`Layout.jsx`) ahora apunta a `/tasks`, y `homeScreen.js` mapea `tasks → /tasks`.

--- a/frontend/src/components/TaskForm.jsx
+++ b/frontend/src/components/TaskForm.jsx
@@ -7,6 +7,7 @@ const FREQ_ICONS = {
   weekly: '📅',
   biweekly: '📆',
   monthly: '🗓️',
+  once: '✅',
 }
 
 function frequencyState(raw) {
@@ -182,7 +183,7 @@ export default function TaskForm({ task, onSave, onCancel }) {
           Frecuencia
         </label>
         <div className="grid grid-cols-4 gap-1.5">
-          {Object.entries(FREQUENCY_LABELS).map(([value, label]) => (
+          {Object.entries(FREQUENCY_LABELS).filter(([value]) => value !== 'once').map(([value, label]) => (
             <button
               key={value}
               type="button"
@@ -199,8 +200,22 @@ export default function TaskForm({ task, onSave, onCancel }) {
             </button>
           ))}
         </div>
+        <button
+          type="button"
+          onClick={() => { set('frequency_type', 'once'); set('frequency_value', '') }}
+          className="mt-1.5 w-full py-2.5 px-3 rounded-xl font-body font-medium text-[12px] transition-all active:scale-[0.98] flex items-center justify-center gap-1.5"
+          style={{
+            background: form.frequency_type === 'once' ? 'var(--moss-400)' : 'var(--surface-elevated)',
+            color: form.frequency_type === 'once' ? 'white' : 'var(--bark-400)',
+            border: `1.5px solid ${form.frequency_type === 'once' ? 'var(--moss-400)' : 'rgba(196,184,166,0.3)'}`,
+          }}
+        >
+          <span className="text-base">{FREQ_ICONS.once}</span>
+          Única vez · se archiva al cumplirse
+        </button>
       </div>
 
+      {form.frequency_type !== 'once' && (
       <div>
         <label className="block font-body font-semibold text-[12px] uppercase tracking-wider mb-1.5" style={{ color: 'var(--bark-400)' }}>
           Dias <span style={{ color: 'var(--bark-300)', fontWeight: 400, textTransform: 'none' }}>(default: {FREQUENCY_DEFAULTS[form.frequency_type]})</span>
@@ -231,6 +246,7 @@ export default function TaskForm({ task, onSave, onCancel }) {
           </p>
         )}
       </div>
+      )}
 
       {/* Product info section */}
       <div>

--- a/frontend/src/lib/__tests__/tasks.test.js
+++ b/frontend/src/lib/__tests__/tasks.test.js
@@ -71,6 +71,17 @@ describe('isTaskPending', () => {
     const old = new Date(Date.now() - 1000 * 60 * 60 * 30).toISOString() // hace 30h
     expect(isTaskPending(task, old)).toBe(true)
   })
+
+  it('una tarea de una sola vez nunca recurre tras completarse', () => {
+    const task = { is_active: true, frequency_type: 'once', frequency_value: 1 }
+    const old = new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString() // hace 30 dias
+    expect(isTaskPending(task, old)).toBe(false)
+  })
+
+  it('una tarea de una sola vez sin completar esta pendiente', () => {
+    const task = { is_active: true, frequency_type: 'once', frequency_value: 1 }
+    expect(isTaskPending(task, null)).toBe(true)
+  })
 })
 
 describe('overdueLabel', () => {
@@ -130,15 +141,20 @@ describe('frequencyLabel', () => {
   it('cae al string del tipo si no hay etiqueta', () => {
     expect(frequencyLabel({ frequency_type: 'custom' })).toBe('custom')
   })
+
+  it('una sola vez siempre muestra "Única vez" sin importar el value', () => {
+    expect(frequencyLabel({ frequency_type: 'once', frequency_value: 1 })).toBe('Única vez')
+    expect(frequencyLabel({ frequency_type: 'once', frequency_value: 5 })).toBe('Única vez')
+  })
 })
 
 describe('constantes de frecuencia', () => {
-  it('FREQUENCY_LABELS tiene las 4 frecuencias', () => {
-    expect(Object.keys(FREQUENCY_LABELS)).toEqual(['daily', 'weekly', 'biweekly', 'monthly'])
+  it('FREQUENCY_LABELS incluye las frecuencias recurrentes y la de una sola vez', () => {
+    expect(Object.keys(FREQUENCY_LABELS)).toEqual(['daily', 'weekly', 'biweekly', 'monthly', 'once'])
   })
 
   it('FREQUENCY_DEFAULTS refleja dias correctos', () => {
-    expect(FREQUENCY_DEFAULTS).toEqual({ daily: 1, weekly: 7, biweekly: 14, monthly: 30 })
+    expect(FREQUENCY_DEFAULTS).toEqual({ daily: 1, weekly: 7, biweekly: 14, monthly: 30, once: 1 })
   })
 })
 

--- a/frontend/src/lib/tasks.js
+++ b/frontend/src/lib/tasks.js
@@ -13,6 +13,7 @@ export const FREQUENCY_LABELS = {
   weekly: 'Semanal',
   biweekly: 'Quincenal',
   monthly: 'Mensual',
+  once: 'Única vez',
 }
 
 export const FREQUENCY_DEFAULTS = {
@@ -20,6 +21,7 @@ export const FREQUENCY_DEFAULTS = {
   weekly: 7,
   biweekly: 14,
   monthly: 30,
+  once: 1,
 }
 
 export function frequencyToHours(type, value) {
@@ -30,6 +32,8 @@ export function frequencyToHours(type, value) {
 export function isTaskPending(task, lastCompletedAt) {
   if (!task.is_active) return false
   if (!lastCompletedAt) return true
+  // Tareas de una sola vez no recurren: una vez completadas dejan de estar pendientes.
+  if (task.frequency_type === 'once') return false
 
   const hours = frequencyToHours(task.frequency_type, task.frequency_value)
   const nextDue = new Date(lastCompletedAt).getTime() + hours * 3600 * 1000
@@ -61,6 +65,7 @@ export function urgencyBucket(task, lastCompletedAt) {
 
 export function frequencyLabel(task) {
   const base = FREQUENCY_LABELS[task.frequency_type] || task.frequency_type
+  if (task.frequency_type === 'once') return base
   if (task.frequency_value && task.frequency_value !== FREQUENCY_DEFAULTS[task.frequency_type]) {
     return `Cada ${task.frequency_value} dias`
   }

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -29,6 +29,11 @@ const FREQ_ICONS = {
       <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 1118 0z"/><circle cx="12" cy="10" r="3"/>
     </svg>
   ),
+  once: (
+    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><path d="M22 4L12 14.01l-3-3"/>
+    </svg>
+  ),
 }
 
 export default function Admin() {

--- a/server/index.js
+++ b/server/index.js
@@ -341,7 +341,7 @@ app.post('/api/houses/seed', requireAuth, requireHouse, requireRole('owner', 'ad
     }
 
     // Insert tasks — from custom array if provided, otherwise from hardcoded templates
-    const validFrequencies = ['daily', 'weekly', 'biweekly', 'monthly']
+    const validFrequencies = ['daily', 'weekly', 'biweekly', 'monthly', 'once']
 
     if (customTasks && customTasks.length > 0) {
       // Validate each task
@@ -512,7 +512,7 @@ app.get('/api/tasks/pending', requireAuth, requireHouse, async (req, res) => {
         AND t.organization_id = $1
         AND (
           c.last_completed_at IS NULL
-          OR NOW() >= c.last_completed_at + (t.frequency_value * INTERVAL '1 day')
+          OR (t.frequency_type <> 'once' AND NOW() >= c.last_completed_at + (t.frequency_value * INTERVAL '1 day'))
           OR (t.last_reset_at IS NOT NULL AND t.last_reset_at > c.last_completed_at)
         )
       ORDER BY t.name
@@ -614,7 +614,7 @@ app.post('/api/completions', requireAuth, requireHouse, async (req, res) => {
     const { task_id, completed_at } = req.body
     // Verify task belongs to this house
     const { rows: taskCheck } = await pool.query(
-      'SELECT id FROM tasks WHERE id = $1 AND organization_id = $2', [task_id, req.house.id]
+      'SELECT id, name, frequency_type FROM tasks WHERE id = $1 AND organization_id = $2', [task_id, req.house.id]
     )
     if (taskCheck.length === 0) return res.status(404).json({ error: 'Tarea no encontrada' })
 
@@ -623,9 +623,16 @@ app.post('/api/completions', requireAuth, requireHouse, async (req, res) => {
       [task_id, completed_at || new Date().toISOString(), req.user.name || null, req.user.id]
     )
 
+    // Tareas efimeras de una sola vez: se desactivan automaticamente al cumplirse.
+    if (taskCheck[0].frequency_type === 'once') {
+      await pool.query(
+        'UPDATE tasks SET is_active = false WHERE id = $1 AND organization_id = $2',
+        [task_id, req.house.id]
+      )
+    }
+
     // Send push notification to house members
-    const { rows: taskInfo } = await pool.query('SELECT name FROM tasks WHERE id = $1', [task_id])
-    const taskName = taskInfo[0]?.name || 'una tarea'
+    const taskName = taskCheck[0].name || 'una tarea'
     const userName = req.user.name || 'Alguien'
     sendPushToHouse(req.house.id, {
       title: 'Tarea completada',


### PR DESCRIPTION
Agrega frecuencia "Única vez": al cumplirse, la tarea se desactiva
automáticamente y no vuelve a aparecer en pendientes, pero queda
inactiva (conserva historial y es reactivable desde Admin).

https://claude.ai/code/session_018KadiYHW7QVjoeQdsd6Szq