### PR TITLE
UI: Navbar y menú móvil "luxury hogar" con saludo dinámico

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,17 @@
 
 ## [Fase 2] — Experiencias Agénticas
 
+### 2026-05-26 — UI: Navbar y menú móvil "luxury hogar"
+- **Visión** — refinamiento del header y drawer lateral para elevar la percepción de marca de "app utilitaria" a "concierge del hogar". Prepara el terreno para los tiers de pago de Fase 3: si la app se ve premium, justifica el precio.
+- **Header** — botón hamburguesa pasó de `border + fondo blanco` (parecía input) a **ghost button** con stroke fino (1.6px) y barra inferior corta para un trazo editorial. El logo card mantiene los colores moss pero gana degradado más profundo (`#7aa870 → #385c32`) con inner highlight + sombra sutil. El título "Perlato" ahora viene acompañado de un **saludo dinámico** ("Buenas tardes, Juan") en micro tipografía body con tracking amplio, dependiente de la hora y del nombre de la sesión.
+- **Drawer** — tres bloques con jerarquía:
+  - **Brand row** — logo casa + nombre + cerrar.
+  - **Welcome card** — avatar grande (48px) con borde de color del perfil, saludo en eyebrow y primer nombre en `font-display` (DM Serif Display). Convierte el menú en un saludo personalizado, no una lista de links.
+  - **Nav agrupada** — items reorganizados en tres secciones con micro-headers en uppercase: *Día a día* (Tareas, Stats), *Inventario* (Productos, Plantas, Compras), *Configuración* (Admin, Casa). Cada item gana un **icono lineal fino** (stroke 1.6) a la izquierda; el item activo conserva la barra acento + fondo elevado + sombra `card`. Fondo del drawer con degradado vertical sutil (`surface-card → surface-base`) y sombra lateral más rica.
+- **CSS** — dos utilidades nuevas en `index.css`: `.nav-ghost-btn` (hover transparente sobre `bark-200`) y `.nav-item` (hover para items inactivos), sin tocar tokens del design system.
+- **Sin cambios de navegación** — rutas, tap targets (>= 44px), aria labels y `ESC`/click-out preservados. Build de Vite verde, frontend 163/163.
+- Archivos: `frontend/src/components/Layout.jsx`, `frontend/src/index.css`.
+
 ### 2026-05-24 — UI: "Única vez" integrada a la grilla de frecuencias
 - **Consistencia visual** — la opción "Única vez" dejó de ser un banner ancho separado y ahora es un recuadro igual a las frecuencias recurrentes, dentro del mismo grid (ahora de 5 columnas: Diario/Semanal/Quincenal/Mensual/Única vez). Rompía con el patrón de selección del resto.
 - **Icono propio** — pasó de `✅` (se confundía con "completado") a `🏁` (bandera de meta: se completa y se archiva).

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -6,6 +6,86 @@ import { fetchHouseProfile, checkSuperAdmin } from '../lib/api'
 import { setStoredHomeScreen } from '../lib/homeScreen'
 import InstallPrompt from './InstallPrompt'
 
+function getGreeting() {
+  const h = new Date().getHours()
+  if (h >= 5 && h < 12) return 'Buenos días'
+  if (h >= 12 && h < 19) return 'Buenas tardes'
+  return 'Buenas noches'
+}
+
+const Icons = {
+  tasks: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="5" y="5" width="14" height="16" rx="2" />
+      <path d="M9 3h6v4H9z" />
+      <path d="M9 13l2 2 4-4" />
+    </svg>
+  ),
+  stats: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 20V11" />
+      <path d="M10 20V4" />
+      <path d="M16 20v-8" />
+      <path d="M22 20v-5" />
+    </svg>
+  ),
+  products: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10 3h4v3l1.6 2.4a3 3 0 0 1 .4 1.5V19a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2v-9.1c0-.5.1-1 .4-1.5L10 6V3z" />
+      <path d="M9 12h6" />
+    </svg>
+  ),
+  plants: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 22v-7" />
+      <path d="M12 15c-4 0-7-3-7-7 4 0 7 3 7 7z" />
+      <path d="M12 15c0-4 3-7 7-7 0 4-3 7-7 7z" />
+    </svg>
+  ),
+  shopping: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M6 7h12l-1.2 13H7.2L6 7z" />
+      <path d="M9 7V5a3 3 0 0 1 6 0v2" />
+    </svg>
+  ),
+  admin: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 3l8 3v5c0 5-3.5 9-8 10-4.5-1-8-5-8-10V6l8-3z" />
+      <path d="M9 12l2 2 4-4" />
+    </svg>
+  ),
+  house: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 11l9-7 9 7v9a2 2 0 0 1-2 2h-4v-7H9v7H5a2 2 0 0 1-2-2v-9z" />
+    </svg>
+  ),
+}
+
+const navSections = [
+  {
+    title: 'Día a día',
+    items: [
+      { to: '/tasks', label: 'Tareas', end: true, activeColor: 'var(--moss-500)', icon: Icons.tasks },
+      { to: '/stats', label: 'Stats', activeColor: 'var(--moss-500)', icon: Icons.stats },
+    ],
+  },
+  {
+    title: 'Inventario',
+    items: [
+      { to: '/products', label: 'Productos', activeColor: 'var(--clay-500)', icon: Icons.products },
+      { to: '/plants', label: 'Plantas', activeColor: 'var(--moss-500)', icon: Icons.plants },
+      { to: '/shopping', label: 'Compras', activeColor: 'var(--clay-500)', icon: Icons.shopping },
+    ],
+  },
+  {
+    title: 'Configuración',
+    items: [
+      { to: '/admin', label: 'Admin', activeColor: 'var(--clay-500)', icon: Icons.admin },
+      { to: '/house-settings', label: 'Casa', activeColor: 'var(--moss-500)', icon: Icons.house },
+    ],
+  },
+]
+
 export default function Layout() {
   const navigate = useNavigate()
   const house = getActiveHouse()
@@ -15,6 +95,9 @@ export default function Layout() {
   const [showMenu, setShowMenu] = useState(false)
   const [isSuperAdmin, setIsSuperAdmin] = useState(false)
   const dropdownRef = useRef(null)
+
+  const firstName = (session?.user?.name || '').trim().split(/\s+/)[0]
+  const greeting = getGreeting()
 
   useEffect(() => {
     fetchHouseProfile().then(p => {
@@ -70,16 +153,6 @@ export default function Layout() {
     navigate('/houses')
   }
 
-  const navItems = [
-    { to: '/tasks', label: 'Tareas', end: true, activeColor: 'var(--moss-500)' },
-    { to: '/stats', label: 'Stats', activeColor: 'var(--moss-500)' },
-    { to: '/products', label: 'Productos', activeColor: 'var(--clay-500)' },
-    { to: '/plants', label: 'Plantas', activeColor: 'var(--moss-500)' },
-    { to: '/shopping', label: 'Compras', activeColor: 'var(--clay-500)' },
-    { to: '/admin', label: 'Admin', activeColor: 'var(--clay-500)' },
-    { to: '/house-settings', label: 'Casa', activeColor: 'var(--moss-500)' },
-  ]
-
   return (
     <div className="min-h-dvh flex flex-col bg-grain" style={{ background: 'var(--surface-base)' }}>
       {/* Subtle gradient orbs */}
@@ -95,36 +168,49 @@ export default function Layout() {
       </div>
 
       {/* Header */}
-      <header className="glass-header sticky top-0 z-20 px-4">
-        <div className="max-w-lg mx-auto flex items-center justify-between h-14 gap-2">
-          <div className="flex items-center gap-2 min-w-0">
+      <header className="glass-header sticky top-0 z-20 px-3 sm:px-4">
+        <div className="max-w-lg mx-auto flex items-center justify-between h-16 gap-2">
+          <div className="flex items-center gap-1 min-w-0">
             <button
               type="button"
               onClick={() => setShowMenu(true)}
               aria-label="Abrir menu"
               aria-expanded={showMenu}
-              className="w-11 h-11 rounded-xl flex items-center justify-center transition-all active:scale-95 hover:shadow-sm flex-shrink-0"
-              style={{ background: 'var(--surface-elevated)', border: '1px solid rgba(196,184,166,0.25)' }}
+              className="w-11 h-11 -ml-1 rounded-xl flex items-center justify-center transition-all active:scale-95 flex-shrink-0 nav-ghost-btn"
+              style={{ color: 'var(--bark-500)' }}
             >
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" style={{ color: 'var(--bark-700)' }}>
-                <path d="M4 6h16" />
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round">
+                <path d="M4 7h16" />
                 <path d="M4 12h16" />
-                <path d="M4 18h16" />
+                <path d="M4 17h11" />
               </svg>
             </button>
-            <NavLink to="/" className="flex items-center gap-2 group min-w-0" end>
+            <NavLink to="/" className="flex items-center gap-2.5 group min-w-0 pl-1" end>
               <div
-                className="w-8 h-8 rounded-lg flex items-center justify-center transition-transform group-hover:scale-105 flex-shrink-0"
-                style={{ background: 'linear-gradient(135deg, #6a9960 0%, #4d7a44 100%)' }}
+                className="w-9 h-9 rounded-xl flex items-center justify-center transition-transform group-hover:scale-105 flex-shrink-0 relative overflow-hidden"
+                style={{
+                  background: 'linear-gradient(140deg, #7aa870 0%, #385c32 100%)',
+                  boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.25), 0 1px 2px rgba(56,92,50,0.25), 0 0 0 1px rgba(56,92,50,0.08)'
+                }}
               >
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-                  <path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                  <path d="M9 22V12h6v10" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none">
+                  <path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" stroke="white" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
+                  <path d="M9 22V12h6v10" stroke="white" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
                 </svg>
               </div>
-              <h1 className="font-display text-base sm:text-lg leading-none truncate" style={{ color: 'var(--bark-700)' }}>
-                {house?.name || 'Casa Limpia'}
-              </h1>
+              <div className="flex flex-col min-w-0 justify-center">
+                <h1 className="font-display text-[17px] sm:text-[18px] leading-none truncate" style={{ color: 'var(--bark-700)', letterSpacing: '-0.01em' }}>
+                  {house?.name || 'Casa Limpia'}
+                </h1>
+                {firstName && (
+                  <span
+                    className="font-body text-[10px] font-semibold uppercase truncate mt-1"
+                    style={{ color: 'var(--bark-300)', letterSpacing: '0.12em' }}
+                  >
+                    {greeting}, {firstName}
+                  </span>
+                )}
+              </div>
             </NavLink>
           </div>
 
@@ -133,17 +219,22 @@ export default function Layout() {
             <div className="relative flex-shrink-0" ref={dropdownRef}>
               <button
                 onClick={() => setShowDropdown(!showDropdown)}
+                aria-label="Abrir menu de perfil"
                 className="flex items-center gap-1.5 pl-1 pr-1 sm:pr-2.5 py-1 rounded-xl transition-all active:scale-95 hover:shadow-sm"
                 style={{ background: 'var(--surface-elevated)', border: '1px solid rgba(196,184,166,0.2)' }}
               >
                 <div
-                  className="w-7 h-7 rounded-full flex items-center justify-center text-sm"
-                  style={{ background: (profile?.color || '#6a9960') + '22', border: `2px solid ${profile?.color || '#6a9960'}` }}
+                  className="w-8 h-8 rounded-full flex items-center justify-center text-base"
+                  style={{
+                    background: (profile?.color || '#6a9960') + '22',
+                    border: `2px solid ${profile?.color || '#6a9960'}`,
+                    boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.4)'
+                  }}
                 >
                   {profile?.avatar || '🧑'}
                 </div>
                 <span className="font-body text-[12px] font-semibold hidden sm:inline" style={{ color: 'var(--bark-500)' }}>
-                  {session?.user?.name || ''}
+                  {firstName || ''}
                 </span>
               </button>
 
@@ -209,21 +300,29 @@ export default function Layout() {
           <aside
             role="dialog"
             aria-label="Menu de navegacion"
-            className="fixed top-0 left-0 bottom-0 z-50 w-[82vw] max-w-xs flex flex-col drawer-slide-in"
-            style={{ background: 'var(--surface-card)', borderRight: '1px solid rgba(196,184,166,0.25)', boxShadow: '4px 0 24px rgba(0,0,0,0.08)' }}
+            className="fixed top-0 left-0 bottom-0 z-50 w-[84vw] max-w-[320px] flex flex-col drawer-slide-in"
+            style={{
+              background: 'linear-gradient(180deg, var(--surface-card) 0%, var(--surface-base) 100%)',
+              borderRight: '1px solid rgba(196,184,166,0.3)',
+              boxShadow: '8px 0 32px rgba(26,22,20,0.10), 2px 0 8px rgba(26,22,20,0.04)'
+            }}
           >
-            <div className="flex items-center justify-between px-5 h-14 flex-shrink-0" style={{ borderBottom: '1px solid rgba(196,184,166,0.2)' }}>
+            {/* Brand row */}
+            <div className="flex items-center justify-between px-5 h-14 flex-shrink-0" style={{ borderBottom: '1px solid rgba(196,184,166,0.18)' }}>
               <div className="flex items-center gap-2 min-w-0">
                 <div
                   className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
-                  style={{ background: 'linear-gradient(135deg, #6a9960 0%, #4d7a44 100%)' }}
+                  style={{
+                    background: 'linear-gradient(140deg, #7aa870 0%, #385c32 100%)',
+                    boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.25), 0 1px 2px rgba(56,92,50,0.25)'
+                  }}
                 >
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none">
                     <path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
                     <path d="M9 22V12h6v10" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
                   </svg>
                 </div>
-                <h2 className="font-display text-base leading-none truncate" style={{ color: 'var(--bark-700)' }}>
+                <h2 className="font-display text-[16px] leading-none truncate" style={{ color: 'var(--bark-700)', letterSpacing: '-0.01em' }}>
                   {house?.name || 'Casa Limpia'}
                 </h2>
               </div>
@@ -231,44 +330,100 @@ export default function Layout() {
                 type="button"
                 onClick={() => setShowMenu(false)}
                 aria-label="Cerrar menu"
-                className="w-9 h-9 rounded-lg flex items-center justify-center transition-all active:scale-95 hover:opacity-70 flex-shrink-0"
+                className="w-9 h-9 rounded-lg flex items-center justify-center transition-all active:scale-95 nav-ghost-btn flex-shrink-0"
                 style={{ color: 'var(--bark-500)' }}
               >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round">
                   <path d="M6 6l12 12" />
                   <path d="M18 6L6 18" />
                 </svg>
               </button>
             </div>
-            <nav className="flex-1 overflow-y-auto py-2 px-2">
-              {navItems.map(item => (
-                <NavLink
-                  key={item.to}
-                  to={item.to}
-                  end={item.end}
-                  onClick={() => setShowMenu(false)}
-                  className={({ isActive }) =>
-                    `flex items-center gap-3 px-3 py-3 rounded-xl font-body text-[15px] font-medium transition-all min-h-[44px] ${
-                      isActive ? 'shadow-sm' : 'hover:opacity-80'
-                    }`
-                  }
-                  style={({ isActive }) => isActive
-                    ? { background: 'var(--surface-elevated)', color: item.activeColor, boxShadow: '0 1px 3px rgba(0,0,0,0.06)' }
-                    : { color: 'var(--bark-700)' }
-                  }
+
+            {/* Welcome card */}
+            <div className="px-5 py-4 flex items-center gap-3 flex-shrink-0" style={{ borderBottom: '1px solid rgba(196,184,166,0.18)' }}>
+              <div
+                className="w-12 h-12 rounded-full flex items-center justify-center text-xl flex-shrink-0"
+                style={{
+                  background: (profile?.color || '#6a9960') + '1f',
+                  border: `2px solid ${profile?.color || '#6a9960'}`,
+                  boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.4), 0 1px 3px rgba(26,22,20,0.06)'
+                }}
+              >
+                {profile?.avatar || '🧑'}
+              </div>
+              <div className="min-w-0 flex flex-col">
+                <span
+                  className="font-body text-[10px] font-semibold uppercase truncate"
+                  style={{ color: 'var(--bark-300)', letterSpacing: '0.14em' }}
                 >
-                  {({ isActive }) => (
-                    <>
-                      <span
-                        className="w-1 h-6 rounded-full transition-all"
-                        style={{ background: isActive ? item.activeColor : 'transparent' }}
-                      />
-                      <span>{item.label}</span>
-                    </>
-                  )}
-                </NavLink>
+                  {greeting}
+                </span>
+                <span
+                  className="font-display text-[19px] leading-tight truncate mt-0.5"
+                  style={{ color: 'var(--bark-700)', letterSpacing: '-0.01em' }}
+                >
+                  {firstName || 'Hola'}
+                </span>
+              </div>
+            </div>
+
+            {/* Nav sections */}
+            <nav className="flex-1 overflow-y-auto py-3 px-3">
+              {navSections.map((section, idx) => (
+                <div key={section.title} className={idx > 0 ? 'mt-5' : ''}>
+                  <div
+                    className="px-3 mb-1.5 font-body text-[10px] font-semibold uppercase"
+                    style={{ color: 'var(--bark-300)', letterSpacing: '0.14em' }}
+                  >
+                    {section.title}
+                  </div>
+                  {section.items.map(item => (
+                    <NavLink
+                      key={item.to}
+                      to={item.to}
+                      end={item.end}
+                      onClick={() => setShowMenu(false)}
+                      className="flex items-center gap-2.5 pl-2 pr-3 py-2.5 rounded-xl font-body text-[15px] font-medium transition-all min-h-[44px] nav-item"
+                      style={({ isActive }) => isActive
+                        ? {
+                            background: 'var(--surface-elevated)',
+                            color: item.activeColor,
+                            boxShadow: '0 1px 3px rgba(26,22,20,0.06), 0 4px 12px rgba(26,22,20,0.04)'
+                          }
+                        : { color: 'var(--bark-700)' }
+                      }
+                    >
+                      {({ isActive }) => (
+                        <>
+                          <span
+                            className="w-[3px] h-6 rounded-full transition-all flex-shrink-0"
+                            style={{ background: isActive ? item.activeColor : 'transparent' }}
+                          />
+                          <span
+                            className="flex items-center justify-center w-5 h-5 flex-shrink-0 transition-colors"
+                            style={{ color: isActive ? item.activeColor : 'var(--bark-400)' }}
+                          >
+                            {item.icon}
+                          </span>
+                          <span>{item.label}</span>
+                        </>
+                      )}
+                    </NavLink>
+                  ))}
+                </div>
               ))}
             </nav>
+
+            {/* Drawer footer */}
+            <div className="flex-shrink-0 px-5 py-3 text-center" style={{ borderTop: '1px solid rgba(196,184,166,0.18)' }}>
+              <span
+                className="font-body text-[10px] font-semibold uppercase"
+                style={{ color: 'var(--bark-300)', letterSpacing: '0.18em' }}
+              >
+                Casa Limpia
+              </span>
+            </div>
           </aside>
         </>
       )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -184,6 +184,26 @@
     animation: drawerSlideIn 0.28s cubic-bezier(0.16, 1, 0.3, 1) forwards;
   }
 
+  /* --- Nav ghost button (hamburger / close) --- */
+  .nav-ghost-btn {
+    background: transparent;
+    transition: background 0.18s ease;
+  }
+  .nav-ghost-btn:hover {
+    background: rgba(196, 184, 166, 0.16);
+  }
+  .nav-ghost-btn:active {
+    background: rgba(196, 184, 166, 0.22);
+  }
+
+  /* --- Drawer nav item (inactive hover) --- */
+  .nav-item {
+    position: relative;
+  }
+  .nav-item:not(.active):hover {
+    background: rgba(196, 184, 166, 0.10);
+  }
+
   /* --- Toast --- */
   .toast-enter {
     animation: toastIn 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards;


### PR DESCRIPTION
## Resumen

Refinamiento integral del header y drawer lateral para elevar la percepción de marca de "app utilitaria" a "concierge del hogar". Prepara el terreno para los tiers de pago de Fase 3: si la app se ve premium, justifica el precio.

## Cambios principales

### Header
- **Botón hamburguesa** pasó de `border + fondo blanco` (parecía input) a **ghost button** con stroke fino (1.6px) y barra inferior corta para un trazo editorial
- **Logo card** mantiene colores moss pero gana degradado más profundo (`#7aa870 → #385c32`) con inner highlight + sombra sutil
- **Saludo dinámico** ("Buenas tardes, Juan") en micro tipografía body con tracking amplio, dependiente de la hora y del nombre de la sesión
- Avatar en dropdown ahora con inner highlight y sombra mejorada

### Drawer lateral
Reorganización en tres bloques con jerarquía clara:

1. **Brand row** — logo casa + nombre + botón cerrar
2. **Welcome card** — avatar grande (48px) con borde de color del perfil, saludo en eyebrow y primer nombre en `font-display` (DM Serif Display). Convierte el menú en un saludo personalizado, no una lista de links
3. **Nav agrupada** — items reorganizados en tres secciones con micro-headers en uppercase:
   - *Día a día* (Tareas, Stats)
   - *Inventario* (Productos, Plantas, Compras)
   - *Configuración* (Admin, Casa)
   
   Cada item gana un **icono lineal fino** (stroke 1.6) a la izquierda; el item activo conserva la barra acento + fondo elevado + sombra `card`

- Fondo del drawer con degradado vertical sutil (`surface-card → surface-base`) y sombra lateral más rica
- Footer con branding "Casa Limpia"

### CSS
Dos utilidades nuevas en `index.css`:
- `.nav-ghost-btn` — hover transparente sobre `bark-200`, transición suave
- `.nav-item` — hover state para items inactivos con fondo sutil

## Detalles de implementación

- **Función `getGreeting()`** — retorna saludo según hora del día (5-12: "Buenos días", 12-19: "Buenas tardes", resto: "Buenas noches")
- **Objeto `Icons`** — SVGs lineales reutilizables para cada sección de nav (tasks, stats, products, plants, shopping, admin, house)
- **Array `navSections`** — estructura jerárquica de navegación con items, labels, colores activos e iconos
- **Extracción de `firstName`** — desde `session.user.name` con trim y split por espacios
- Mejoras de accesibilidad: `aria-label` y `aria-expanded` en botones de menú
- Responsive: ajustes de padding y tamaños para mobile (360px+) y desktop

## Fase del roadmap

**Fase 2 — Experiencias Agénticas**: Refinamiento de UX para preparar monetización (Fase 3)

https://claude.ai/code/session_019ZAhwhxgko4pp5gvgQ4Ryy