### PR TITLE
feat: code graph del server (API -> Handler -> SQL + indice por tabla)

### DIFF
--- a/.claude/code-graph.json
+++ b/.claude/code-graph.json
@@ -1,0 +1,3562 @@
+{
+  "generatedAt": "2026-05-27T23:26:31.706Z",
+  "sources": [
+    "server/index.js",
+    "server/auth.js",
+    "server/lib/middleware.js",
+    "server/lib/patch-update.js",
+    "server/lib/shopping-recommendations.js",
+    "db/init.sql"
+  ],
+  "schema": {
+    "tasks": {
+      "columns": [
+        {
+          "name": "id",
+          "type": "UUID"
+        },
+        {
+          "name": "name",
+          "type": "TEXT"
+        },
+        {
+          "name": "description",
+          "type": "TEXT"
+        },
+        {
+          "name": "frequency_type",
+          "type": "TEXT"
+        },
+        {
+          "name": "frequency_value",
+          "type": "INTEGER"
+        },
+        {
+          "name": "is_active",
+          "type": "BOOLEAN"
+        },
+        {
+          "name": "product_name",
+          "type": "TEXT"
+        },
+        {
+          "name": "product_image",
+          "type": "TEXT"
+        },
+        {
+          "name": "organization_id",
+          "type": "TEXT"
+        },
+        {
+          "name": "last_reset_at",
+          "type": "TIMESTAMPTZ"
+        },
+        {
+          "name": "created_at",
+          "type": "TIMESTAMPTZ"
+        }
+      ],
+      "fks": [],
+      "hasOrgId": true,
+      "source": "db/init.sql"
+    },
+    "completions": {
+      "columns": [
+        {
+          "name": "id",
+          "type": "UUID"
+        },
+        {
+          "name": "task_id",
+          "type": "UUID"
+        },
+        {
+          "name": "completed_at",
+          "type": "TIMESTAMPTZ"
+        },
+        {
+          "name": "completed_by",
+          "type": "TEXT"
+        },
+        {
+          "name": "user_id",
+          "type": "TEXT"
+        }
+      ],
+      "fks": [
+        {
+          "column": "task_id",
+          "refTable": "tasks",
+          "refColumn": "id"
+        }
+      ],
+      "hasOrgId": false,
+      "source": "db/init.sql"
+    },
+    "products": {
+      "columns": [
+        {
+          "name": "id",
+          "type": "UUID"
+        },
+        {
+          "name": "name",
+          "type": "TEXT"
+        },
+        {
+          "name": "category",
+          "type": "TEXT"
+        },
+        {
+          "name": "is_out_of_stock",
+          "type": "BOOLEAN"
+        },
+        {
+          "name": "reminder_frequency_days",
+          "type": "INTEGER"
+        },
+        {
+          "name": "units",
+          "type": "INTEGER"
+        },
+        {
+          "name": "last_purchased_at",
+          "type": "TIMESTAMPTZ"
+        },
+        {
+          "name": "last_out_of_stock_at",
+          "type": "TIMESTAMPTZ"
+        },
+        {
+          "name": "organization_id",
+          "type": "TEXT"
+        },
+        {
+          "name": "created_at",
+          "type": "TIMESTAMPTZ"
+        }
+      ],
+      "fks": [],
+      "hasOrgId": true,
+      "source": "db/init.sql"
+    },
+    "shopping_categories": {
+      "columns": [
+        {
+          "name": "id",
+          "type": "UUID"
+        },
+        {
+          "name": "name",
+          "type": "TEXT"
+        },
+        {
+          "name": "emoji",
+          "type": "TEXT"
+        },
+        {
+          "name": "sort_order",
+          "type": "INTEGER"
+        },
+        {
+          "name": "organization_id",
+          "type": "TEXT"
+        },
+        {
+          "name": "created_at",
+          "type": "TIMESTAMPTZ"
+        }
+      ],
+      "fks": [],
+      "hasOrgId": true,
+      "source": "db/init.sql"
+    },
+    "shopping_items": {
+      "columns": [
+        {
+          "name": "id",
+          "type": "UUID"
+        },
+        {
+          "name": "name",
+          "type": "TEXT"
+        },
+        {
+          "name": "note",
+          "type": "TEXT"
+        },
+        {
+          "name": "added_by",
+          "type": "TEXT"
+        },
+        {
+          "name": "is_purchased",
+          "type": "BOOLEAN"
+        },
+        {
+          "name": "category_id",
+          "type": "UUID"
+        },
+        {
+          "name": "organization_id",
+          "type": "TEXT"
+        },
+        {
+          "name": "purchased_at",
+          "type": "TIMESTAMPTZ"
+        },
+        {
+          "name": "archived_at",
+          "type": "TIMESTAMPTZ"
+        },
+        {
+          "name": "created_at",
+          "type": "TIMESTAMPTZ"
+        }
+      ],
+      "fks": [
+        {
+          "column": "category_id",
+          "refTable": "shopping_categories",
+          "refColumn": "id"
+        }
+      ],
+      "hasOrgId": true,
+      "source": "db/init.sql"
+    },
+    "house_member_profiles": {
+      "columns": [
+        {
+          "name": "id",
+          "type": "UUID"
+        },
+        {
+          "name": "user_id",
+          "type": "TEXT"
+        },
+        {
+          "name": "organization_id",
+          "type": "TEXT"
+        },
+        {
+          "name": "avatar",
+          "type": "TEXT"
+        },
+        {
+          "name": "color",
+          "type": "TEXT"
+        },
+        {
+          "name": "home_screen",
+          "type": "TEXT"
+        },
+        {
+          "name": "created_at",
+          "type": "TIMESTAMPTZ"
+        }
+      ],
+      "fks": [],
+      "hasOrgId": true,
+      "source": "db/init.sql"
+    },
+    "super_admins": {
+      "columns": [
+        {
+          "name": "id",
+          "type": "UUID"
+        },
+        {
+          "name": "user_id",
+          "type": "TEXT"
+        },
+        {
+          "name": "created_at",
+          "type": "TIMESTAMPTZ"
+        }
+      ],
+      "fks": [],
+      "hasOrgId": false,
+      "source": "db/init.sql"
+    },
+    "plants": {
+      "columns": [
+        {
+          "name": "id",
+          "type": "UUID"
+        },
+        {
+          "name": "name",
+          "type": "TEXT"
+        },
+        {
+          "name": "notes",
+          "type": "TEXT"
+        },
+        {
+          "name": "watering_frequency_days",
+          "type": "INTEGER"
+        },
+        {
+          "name": "last_watered_at",
+          "type": "TIMESTAMPTZ"
+        },
+        {
+          "name": "organization_id",
+          "type": "TEXT"
+        },
+        {
+          "name": "created_at",
+          "type": "TIMESTAMPTZ"
+        }
+      ],
+      "fks": [],
+      "hasOrgId": true,
+      "source": "db/init.sql"
+    },
+    "plant_watering_history": {
+      "columns": [
+        {
+          "name": "id",
+          "type": "UUID"
+        },
+        {
+          "name": "plant_id",
+          "type": "UUID"
+        },
+        {
+          "name": "watered_at",
+          "type": "TIMESTAMPTZ"
+        },
+        {
+          "name": "watered_by",
+          "type": "TEXT"
+        },
+        {
+          "name": "user_id",
+          "type": "TEXT"
+        }
+      ],
+      "fks": [
+        {
+          "column": "plant_id",
+          "refTable": "plants",
+          "refColumn": "id"
+        }
+      ],
+      "hasOrgId": false,
+      "source": "db/init.sql"
+    },
+    "push_subscriptions": {
+      "columns": [
+        {
+          "name": "id",
+          "type": "UUID"
+        },
+        {
+          "name": "user_id",
+          "type": "TEXT"
+        },
+        {
+          "name": "organization_id",
+          "type": "TEXT"
+        },
+        {
+          "name": "endpoint",
+          "type": "TEXT"
+        },
+        {
+          "name": "keys_p256dh",
+          "type": "TEXT"
+        },
+        {
+          "name": "keys_auth",
+          "type": "TEXT"
+        },
+        {
+          "name": "created_at",
+          "type": "TIMESTAMPTZ"
+        },
+        {
+          "name": "updated_at",
+          "type": "TIMESTAMPTZ"
+        }
+      ],
+      "fks": [],
+      "hasOrgId": true,
+      "source": "server/index.js:1450"
+    }
+  },
+  "routes": [
+    {
+      "file": "server/index.js",
+      "method": "ALL",
+      "path": "/api/auth/*",
+      "line": 79,
+      "middlewares": [],
+      "queries": []
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/super-admin/check",
+      "line": 88,
+      "middlewares": [
+        "requireAuth"
+      ],
+      "queries": [
+        {
+          "line": 90,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT id FROM super_admins WHERE user_id = $1",
+          "op": "SELECT",
+          "tables": [
+            "super_admins"
+          ],
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/super-admin/stats",
+      "line": 101,
+      "middlewares": [
+        "requireAuth",
+        "requireSuperAdmin"
+      ],
+      "queries": [
+        {
+          "line": 104,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT COUNT(*) as count FROM \"user\"",
+          "op": "SELECT",
+          "tables": [
+            "user"
+          ],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 105,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT COUNT(*) as count FROM \"organization\"",
+          "op": "SELECT",
+          "tables": [
+            "organization"
+          ],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 106,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT COUNT(*) as count FROM \"member\"",
+          "op": "SELECT",
+          "tables": [
+            "member"
+          ],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 107,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT COUNT(*) as count FROM tasks",
+          "op": "SELECT",
+          "tables": [
+            "tasks"
+          ],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 108,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT COUNT(*) as count FROM completions",
+          "op": "SELECT",
+          "tables": [
+            "completions"
+          ],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 109,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT DATE(completed_at) as day, COUNT(*) as count\n        FROM completions\n        WHERE completed_at >= NOW() - INTERVAL '30 days'\n        GROUP BY DATE(completed_at)\n        ORDER BY day",
+          "op": "SELECT",
+          "tables": [
+            "completions"
+          ],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 116,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT o.id, o.name, o.slug, COUNT(DISTINCT m.\"userId\") as member_count,\n               COUNT(DISTINCT t.id) as task_count,\n               COUNT(DISTINCT c.id) as completion_count,\n               MAX(c.completed_at) as last_activity\n        FROM \"organization\" o\n        LEFT JOIN \"member\" m ON m.\"organizationId\" = o.id\n        LEFT JOIN tasks t ON t.organization_id = o.id\n        LEFT JOIN completions c ON c.task_id = t.id\n        GROUP BY o.id, o.name, o.slug\n        ORDER BY last_activity DESC NULLS LAST",
+          "op": "SELECT",
+          "tables": [
+            "organization",
+            "member",
+            "tasks",
+            "completions"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/houses/members",
+      "line": 158,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 160,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT m.\"userId\", m.role, m.\"createdAt\",\n             u.name, u.email,\n             COALESCE(p.avatar, '🧑') as avatar,\n             COALESCE(p.color, '#6a9960') as color\n      FROM \"member\" m\n      JOIN \"user\" u ON m.\"userId\" = u.id\n      LEFT JOIN house_member_profiles p ON p.user_id = m.\"userId\" AND p.organization_id = m.\"organizationId\"\n      WHERE m.\"organizationId\" = $1\n      ORDER BY m.\"createdAt\"",
+          "op": "SELECT",
+          "tables": [
+            "member",
+            "user",
+            "house_member_profiles"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/houses/profile",
+      "line": 180,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 182,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT * FROM house_member_profiles WHERE user_id = $1 AND organization_id = $2",
+          "op": "SELECT",
+          "tables": [
+            "house_member_profiles"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "PUT",
+      "path": "/api/houses/profile",
+      "line": 198,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 204,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT avatar, color, home_screen FROM house_member_profiles WHERE user_id = $1 AND organization_id = $2",
+          "op": "SELECT",
+          "tables": [
+            "house_member_profiles"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 212,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "INSERT INTO house_member_profiles (user_id, organization_id, avatar, color, home_screen)\n      VALUES ($1, $2, $3, $4, $5)\n      ON CONFLICT (user_id, organization_id)\n      DO UPDATE SET avatar = EXCLUDED.avatar, color = EXCLUDED.color, home_screen = EXCLUDED.home_screen\n      RETURNING *",
+          "op": "INSERT",
+          "tables": [
+            "house_member_profiles"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/invitations",
+      "line": 226,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse",
+        "requireRole('owner', 'admin')"
+      ],
+      "queries": [
+        {
+          "line": 228,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT i.id, i.email, i.role, i.status, i.\"expiresAt\", i.\"inviterId\",\n             u.name as inviter_name, u.email as inviter_email\n      FROM \"invitation\" i\n      LEFT JOIN \"user\" u ON u.id = i.\"inviterId\"\n      WHERE i.\"organizationId\" = $1 AND i.status = 'pending'\n      ORDER BY i.\"expiresAt\" DESC",
+          "op": "SELECT",
+          "tables": [
+            "invitation",
+            "user"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "DELETE",
+      "path": "/api/invitations/:id",
+      "line": 243,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse",
+        "requireRole('owner', 'admin')"
+      ],
+      "queries": [
+        {
+          "line": 245,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "DELETE FROM \"invitation\" WHERE id = $1 AND \"organizationId\" = $2 AND status = 'pending'",
+          "op": "DELETE",
+          "tables": [
+            "invitation"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "POST",
+      "path": "/api/invitations/:id/renew",
+      "line": 259,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse",
+        "requireRole('owner', 'admin')"
+      ],
+      "queries": [
+        {
+          "line": 261,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "UPDATE \"invitation\"\n       SET \"expiresAt\" = NOW() + INTERVAL '7 days'\n       WHERE id = $1 AND \"organizationId\" = $2 AND status = 'pending'\n       RETURNING id, email, role, status, \"expiresAt\"",
+          "op": "UPDATE",
+          "tables": [
+            "invitation"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "DELETE",
+      "path": "/api/houses/:id",
+      "line": 278,
+      "middlewares": [
+        "requireAuth"
+      ],
+      "queries": [
+        {
+          "line": 285,
+          "client": "client",
+          "dynamic": false,
+          "sql": "SELECT role FROM \"member\" WHERE \"userId\" = $1 AND \"organizationId\" = $2",
+          "op": "SELECT",
+          "tables": [
+            "member"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 296,
+          "client": "client",
+          "dynamic": false,
+          "sql": "BEGIN",
+          "op": "BEGIN",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 298,
+          "client": "client",
+          "dynamic": false,
+          "sql": "DELETE FROM tasks WHERE organization_id = $1",
+          "op": "DELETE",
+          "tables": [
+            "tasks"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 299,
+          "client": "client",
+          "dynamic": false,
+          "sql": "DELETE FROM products WHERE organization_id = $1",
+          "op": "DELETE",
+          "tables": [
+            "products"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 300,
+          "client": "client",
+          "dynamic": false,
+          "sql": "DELETE FROM shopping_items WHERE organization_id = $1",
+          "op": "DELETE",
+          "tables": [
+            "shopping_items"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 301,
+          "client": "client",
+          "dynamic": false,
+          "sql": "DELETE FROM shopping_categories WHERE organization_id = $1",
+          "op": "DELETE",
+          "tables": [
+            "shopping_categories"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 302,
+          "client": "client",
+          "dynamic": false,
+          "sql": "DELETE FROM house_member_profiles WHERE organization_id = $1",
+          "op": "DELETE",
+          "tables": [
+            "house_member_profiles"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 303,
+          "client": "client",
+          "dynamic": false,
+          "sql": "DELETE FROM push_subscriptions WHERE organization_id = $1",
+          "op": "DELETE",
+          "tables": [
+            "push_subscriptions"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 304,
+          "client": "client",
+          "dynamic": false,
+          "sql": "DELETE FROM plant_watering_history WHERE plant_id IN (SELECT id FROM plants WHERE organization_id = $1)",
+          "op": "DELETE",
+          "tables": [
+            "plant_watering_history",
+            "plants"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 308,
+          "client": "client",
+          "dynamic": false,
+          "sql": "DELETE FROM plants WHERE organization_id = $1",
+          "op": "DELETE",
+          "tables": [
+            "plants"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 310,
+          "client": "client",
+          "dynamic": false,
+          "sql": "DELETE FROM \"invitation\" WHERE \"organizationId\" = $1",
+          "op": "DELETE",
+          "tables": [
+            "invitation"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 311,
+          "client": "client",
+          "dynamic": false,
+          "sql": "DELETE FROM \"member\" WHERE \"organizationId\" = $1",
+          "op": "DELETE",
+          "tables": [
+            "member"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 312,
+          "client": "client",
+          "dynamic": false,
+          "sql": "DELETE FROM \"organization\" WHERE id = $1",
+          "op": "DELETE",
+          "tables": [
+            "organization"
+          ],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 313,
+          "client": "client",
+          "dynamic": false,
+          "sql": "COMMIT",
+          "op": "COMMIT",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 317,
+          "client": "client",
+          "dynamic": false,
+          "sql": "ROLLBACK",
+          "op": "ROLLBACK",
+          "tables": [],
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "POST",
+      "path": "/api/houses/seed",
+      "line": 325,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse",
+        "requireRole('owner', 'admin')"
+      ],
+      "queries": [
+        {
+          "line": 332,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT COUNT(*) as c FROM tasks WHERE organization_id = $1",
+          "op": "SELECT",
+          "tables": [
+            "tasks"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 368,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "INSERT INTO tasks (name, description, frequency_type, frequency_value, is_active, organization_id) VALUES ${values}",
+          "op": "INSERT",
+          "tables": [
+            "tasks"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 404,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "INSERT INTO tasks (name, description, frequency_type, frequency_value, is_active, organization_id) VALUES ${values}",
+          "op": "INSERT",
+          "tables": [
+            "tasks"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 460,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "INSERT INTO products (name, category, reminder_frequency_days, is_out_of_stock, organization_id) VALUES ${pValues}",
+          "op": "INSERT",
+          "tables": [
+            "products"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/health",
+      "line": 473,
+      "middlewares": [],
+      "queries": [
+        {
+          "line": 475,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT 1",
+          "op": "SELECT",
+          "tables": [],
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "POST",
+      "path": "/api/uploads",
+      "line": 484,
+      "middlewares": [
+        "requireAuth",
+        "upload.single('image')"
+      ],
+      "queries": []
+    },
+    {
+      "file": "server/index.js",
+      "method": "DELETE",
+      "path": "/api/uploads/:filename",
+      "line": 489,
+      "middlewares": [
+        "requireAuth"
+      ],
+      "queries": []
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/tasks/pending",
+      "line": 501,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 503,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT t.*, c.last_completed_at\n      FROM tasks t\n      LEFT JOIN (\n        SELECT task_id, MAX(completed_at) AS last_completed_at\n        FROM completions\n        GROUP BY task_id\n      ) c ON t.id = c.task_id\n      WHERE t.is_active = true\n        AND t.organization_id = $1\n        AND (\n          c.last_completed_at IS NULL\n          OR (t.frequency_type <> 'once' AND NOW() >= c.last_completed_at + (t.frequency_value * INTERVAL '1 day'))\n          OR (t.last_reset_at IS NOT NULL AND t.last_reset_at > c.last_completed_at)\n        )\n      ORDER BY t.name",
+          "op": "SELECT",
+          "tables": [
+            "tasks",
+            "completions"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/tasks",
+      "line": 527,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 533,
+          "client": "pool",
+          "dynamic": true,
+          "sql": null,
+          "op": "DYNAMIC",
+          "tables": [],
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "POST",
+      "path": "/api/tasks",
+      "line": 541,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse",
+        "requireRole('owner', 'admin')"
+      ],
+      "queries": [
+        {
+          "line": 544,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "INSERT INTO tasks (name, description, frequency_type, frequency_value, is_active, product_name, product_image, organization_id)\n       VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *",
+          "op": "INSERT",
+          "tables": [
+            "tasks"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "PATCH",
+      "path": "/api/tasks/:id",
+      "line": 556,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse",
+        "requireRole('owner', 'admin')"
+      ],
+      "queries": [
+        {
+          "line": 566,
+          "client": "pool",
+          "dynamic": true,
+          "sql": null,
+          "op": "DYNAMIC",
+          "tables": [],
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "DELETE",
+      "path": "/api/tasks/:id",
+      "line": 575,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse",
+        "requireRole('owner', 'admin')"
+      ],
+      "queries": [
+        {
+          "line": 578,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT product_image FROM tasks WHERE id = $1 AND organization_id = $2",
+          "op": "SELECT",
+          "tables": [
+            "tasks"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 585,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "DELETE FROM completions WHERE task_id = $1",
+          "op": "DELETE",
+          "tables": [
+            "completions"
+          ],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 586,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "DELETE FROM tasks WHERE id = $1 AND organization_id = $2",
+          "op": "DELETE",
+          "tables": [
+            "tasks"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/completions",
+      "line": 596,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 598,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT c.task_id, c.completed_at, c.completed_by, c.user_id\n      FROM completions c\n      JOIN tasks t ON c.task_id = t.id\n      WHERE t.organization_id = $1\n      ORDER BY c.completed_at DESC",
+          "op": "SELECT",
+          "tables": [
+            "completions",
+            "tasks"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "POST",
+      "path": "/api/completions",
+      "line": 612,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 616,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT id, name, frequency_type FROM tasks WHERE id = $1 AND organization_id = $2",
+          "op": "SELECT",
+          "tables": [
+            "tasks"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 621,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "INSERT INTO completions (task_id, completed_at, completed_by, user_id) VALUES ($1, $2, $3, $4) RETURNING *",
+          "op": "INSERT",
+          "tables": [
+            "completions"
+          ],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 628,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "UPDATE tasks SET is_active = false WHERE id = $1 AND organization_id = $2",
+          "op": "UPDATE",
+          "tables": [
+            "tasks"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "POST",
+      "path": "/api/tasks/:id/reset",
+      "line": 651,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse",
+        "requireRole('owner', 'admin')"
+      ],
+      "queries": [
+        {
+          "line": 654,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "UPDATE tasks SET last_reset_at = NOW() WHERE id = $1 AND organization_id = $2 RETURNING *",
+          "op": "UPDATE",
+          "tables": [
+            "tasks"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/completions/:taskId/history",
+      "line": 666,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 669,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT c.* FROM completions c\n      JOIN tasks t ON c.task_id = t.id\n      WHERE c.task_id = $1 AND t.organization_id = $2\n      ORDER BY c.completed_at DESC LIMIT $3",
+          "op": "SELECT",
+          "tables": [
+            "completions",
+            "tasks"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/products",
+      "line": 684,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 700,
+          "client": "pool",
+          "dynamic": true,
+          "sql": null,
+          "op": "DYNAMIC",
+          "tables": [],
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "POST",
+      "path": "/api/products",
+      "line": 708,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 712,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "INSERT INTO products (name, category, reminder_frequency_days, is_out_of_stock, units, organization_id)\n       VALUES ($1, $2, $3, $4, $5, $6) RETURNING *",
+          "op": "INSERT",
+          "tables": [
+            "products"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "PATCH",
+      "path": "/api/products/:id",
+      "line": 724,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 740,
+          "client": "pool",
+          "dynamic": true,
+          "sql": null,
+          "op": "DYNAMIC",
+          "tables": [],
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "POST",
+      "path": "/api/products/:id/purchase",
+      "line": 749,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 752,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "UPDATE products\n       SET last_purchased_at = NOW(), is_out_of_stock = false, last_out_of_stock_at = NULL\n       WHERE id = $1 AND organization_id = $2 RETURNING *",
+          "op": "UPDATE",
+          "tables": [
+            "products"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "DELETE",
+      "path": "/api/products/:id",
+      "line": 766,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 769,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "DELETE FROM products WHERE id = $1 AND organization_id = $2",
+          "op": "DELETE",
+          "tables": [
+            "products"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/shopping-categories",
+      "line": 779,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 781,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT * FROM shopping_categories WHERE organization_id = $1 ORDER BY sort_order, name",
+          "op": "SELECT",
+          "tables": [
+            "shopping_categories"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "POST",
+      "path": "/api/shopping-categories",
+      "line": 792,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse",
+        "requireRole('owner', 'admin')"
+      ],
+      "queries": [
+        {
+          "line": 797,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT COALESCE(MAX(sort_order), -1) + 1 as next_order FROM shopping_categories WHERE organization_id = $1",
+          "op": "SELECT",
+          "tables": [
+            "shopping_categories"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 801,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "INSERT INTO shopping_categories (name, emoji, sort_order, organization_id) VALUES ($1, $2, $3, $4) RETURNING *",
+          "op": "INSERT",
+          "tables": [
+            "shopping_categories"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "PATCH",
+      "path": "/api/shopping-categories/:id",
+      "line": 812,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse",
+        "requireRole('owner', 'admin')"
+      ],
+      "queries": [
+        {
+          "line": 822,
+          "client": "pool",
+          "dynamic": true,
+          "sql": null,
+          "op": "DYNAMIC",
+          "tables": [],
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "DELETE",
+      "path": "/api/shopping-categories/:id",
+      "line": 831,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse",
+        "requireRole('owner', 'admin')"
+      ],
+      "queries": [
+        {
+          "line": 834,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "DELETE FROM shopping_categories WHERE id = $1 AND organization_id = $2",
+          "op": "DELETE",
+          "tables": [
+            "shopping_categories"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/shopping-items",
+      "line": 844,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 847,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "UPDATE shopping_items\n       SET archived_at = NOW()\n       WHERE organization_id = $1\n         AND is_purchased = true\n         AND archived_at IS NULL\n         AND purchased_at IS NOT NULL\n         AND purchased_at < NOW() - ($2 || ' days')::INTERVAL",
+          "op": "UPDATE",
+          "tables": [
+            "shopping_items"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 858,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT si.*, sc.name as category_name, sc.emoji as category_emoji\n      FROM shopping_items si\n      LEFT JOIN shopping_categories sc ON si.category_id = sc.id\n      WHERE si.organization_id = $1 AND si.archived_at IS NULL\n      ORDER BY si.is_purchased, sc.sort_order NULLS LAST, si.created_at DESC",
+          "op": "SELECT",
+          "tables": [
+            "shopping_items",
+            "shopping_categories"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "POST",
+      "path": "/api/shopping-items",
+      "line": 872,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 876,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "INSERT INTO shopping_items (name, note, added_by, category_id, organization_id) VALUES ($1, $2, $3, $4, $5) RETURNING *",
+          "op": "INSERT",
+          "tables": [
+            "shopping_items"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "PATCH",
+      "path": "/api/shopping-items/:id",
+      "line": 887,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 909,
+          "client": "pool",
+          "dynamic": true,
+          "sql": null,
+          "op": "DYNAMIC",
+          "tables": [],
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "DELETE",
+      "path": "/api/shopping-items/clear-purchased",
+      "line": 919,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 922,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "UPDATE shopping_items\n       SET purchased_at = COALESCE(purchased_at, NOW()),\n           archived_at = NOW()\n       WHERE is_purchased = true\n         AND archived_at IS NULL\n         AND organization_id = $1",
+          "op": "UPDATE",
+          "tables": [
+            "shopping_items"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/shopping-items/history",
+      "line": 939,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 942,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT si.*, sc.name as category_name, sc.emoji as category_emoji\n      FROM shopping_items si\n      LEFT JOIN shopping_categories sc ON si.category_id = sc.id\n      WHERE si.organization_id = $1 AND si.archived_at IS NOT NULL\n      ORDER BY si.archived_at DESC, si.purchased_at DESC NULLS LAST\n      LIMIT $2",
+          "op": "SELECT",
+          "tables": [
+            "shopping_items",
+            "shopping_categories"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/shopping-items/recommendations",
+      "line": 958,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 960,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT si.id, si.name, si.category_id, si.purchased_at,\n             sc.name as category_name, sc.emoji as category_emoji\n      FROM shopping_items si\n      LEFT JOIN shopping_categories sc ON si.category_id = sc.id\n      WHERE si.organization_id = $1\n        AND si.archived_at IS NOT NULL\n        AND si.purchased_at IS NOT NULL\n      ORDER BY si.purchased_at DESC",
+          "op": "SELECT",
+          "tables": [
+            "shopping_items",
+            "shopping_categories"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 971,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT name FROM shopping_items\n       WHERE organization_id = $1 AND archived_at IS NULL",
+          "op": "SELECT",
+          "tables": [
+            "shopping_items"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "DELETE",
+      "path": "/api/shopping-items/:id",
+      "line": 985,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 988,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "DELETE FROM shopping_items WHERE id = $1 AND organization_id = $2",
+          "op": "DELETE",
+          "tables": [
+            "shopping_items"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/plants",
+      "line": 998,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 1000,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT * FROM plants WHERE organization_id = $1 ORDER BY name",
+          "op": "SELECT",
+          "tables": [
+            "plants"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "POST",
+      "path": "/api/plants",
+      "line": 1011,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 1016,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "INSERT INTO plants (name, notes, watering_frequency_days, organization_id)\n       VALUES ($1, $2, $3, $4) RETURNING *",
+          "op": "INSERT",
+          "tables": [
+            "plants"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "PATCH",
+      "path": "/api/plants/:id",
+      "line": 1028,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 1035,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "UPDATE plants SET name = $3, notes = $4, watering_frequency_days = $5\n       WHERE id = $1 AND organization_id = $2 RETURNING *",
+          "op": "UPDATE",
+          "tables": [
+            "plants"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "DELETE",
+      "path": "/api/plants/:id",
+      "line": 1048,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 1051,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "DELETE FROM plants WHERE id = $1 AND organization_id = $2",
+          "op": "DELETE",
+          "tables": [
+            "plants"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "POST",
+      "path": "/api/plants/:id/water",
+      "line": 1063,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 1067,
+          "client": "client",
+          "dynamic": false,
+          "sql": "SELECT id, name FROM plants WHERE id = $1 AND organization_id = $2",
+          "op": "SELECT",
+          "tables": [
+            "plants"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1073,
+          "client": "client",
+          "dynamic": false,
+          "sql": "BEGIN",
+          "op": "BEGIN",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1074,
+          "client": "client",
+          "dynamic": false,
+          "sql": "INSERT INTO plant_watering_history (plant_id, watered_at, watered_by, user_id) VALUES ($1, NOW(), $2, $3)",
+          "op": "INSERT",
+          "tables": [
+            "plant_watering_history"
+          ],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1078,
+          "client": "client",
+          "dynamic": false,
+          "sql": "UPDATE plants SET last_watered_at = NOW() WHERE id = $1 AND organization_id = $2 RETURNING *",
+          "op": "UPDATE",
+          "tables": [
+            "plants"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1082,
+          "client": "client",
+          "dynamic": false,
+          "sql": "COMMIT",
+          "op": "COMMIT",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1092,
+          "client": "client",
+          "dynamic": false,
+          "sql": "ROLLBACK",
+          "op": "ROLLBACK",
+          "tables": [],
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/plants/:id/history",
+      "line": 1100,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 1103,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT h.* FROM plant_watering_history h\n      JOIN plants p ON h.plant_id = p.id\n      WHERE h.plant_id = $1 AND p.organization_id = $2\n      ORDER BY h.watered_at DESC LIMIT $3",
+          "op": "SELECT",
+          "tables": [
+            "plant_watering_history",
+            "plants"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/stats/participation",
+      "line": 1118,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 1129,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT\n        c.user_id,\n        COALESCE(c.completed_by, 'Desconocido') as name,\n        COALESCE(p.avatar, '🧑') as avatar,\n        COALESCE(p.color, '#6a9960') as color,\n        COUNT(*) as completions\n      FROM completions c\n      JOIN tasks t ON c.task_id = t.id\n      LEFT JOIN house_member_profiles p ON p.user_id = c.user_id AND p.organization_id = t.organization_id\n      WHERE t.organization_id = $1 ${dateFilter}\n      GROUP BY c.user_id, c.completed_by, p.avatar, p.color\n      ORDER BY completions DESC",
+          "op": "SELECT",
+          "tables": [
+            "completions",
+            "tasks",
+            "house_member_profiles"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1149,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT\n        DATE(c.completed_at) as date,\n        COUNT(*) as count\n      FROM completions c\n      JOIN tasks t ON c.task_id = t.id\n      WHERE t.organization_id = $1\n        AND c.completed_at >= NOW() - INTERVAL '${chartDays} days'\n      GROUP BY DATE(c.completed_at)\n      ORDER BY date",
+          "op": "SELECT",
+          "tables": [
+            "completions",
+            "tasks"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1162,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT\n        t.name,\n        COUNT(*) as completions\n      FROM completions c\n      JOIN tasks t ON c.task_id = t.id\n      WHERE t.organization_id = $1 ${dateFilter}\n      GROUP BY t.name\n      ORDER BY completions DESC\n      LIMIT 5",
+          "op": "SELECT",
+          "tables": [
+            "completions",
+            "tasks"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/push/vapid-key",
+      "line": 1204,
+      "middlewares": [],
+      "queries": []
+    },
+    {
+      "file": "server/index.js",
+      "method": "POST",
+      "path": "/api/push/subscribe",
+      "line": 1211,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 1218,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "INSERT INTO push_subscriptions (user_id, organization_id, endpoint, keys_p256dh, keys_auth)\n      VALUES ($1, $2, $3, $4, $5)\n      ON CONFLICT (endpoint) DO UPDATE SET\n        user_id = EXCLUDED.user_id,\n        organization_id = EXCLUDED.organization_id,\n        keys_p256dh = EXCLUDED.keys_p256dh,\n        keys_auth = EXCLUDED.keys_auth,\n        updated_at = NOW()",
+          "op": "INSERT",
+          "tables": [
+            "push_subscriptions"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "DELETE",
+      "path": "/api/push/subscribe",
+      "line": 1236,
+      "middlewares": [
+        "requireAuth"
+      ],
+      "queries": [
+        {
+          "line": 1240,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "DELETE FROM push_subscriptions WHERE endpoint = $1 AND user_id = $2",
+          "op": "DELETE",
+          "tables": [
+            "push_subscriptions"
+          ],
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/push/status",
+      "line": 1248,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 1250,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT id FROM push_subscriptions WHERE user_id = $1 AND organization_id = $2 LIMIT 1",
+          "op": "SELECT",
+          "tables": [
+            "push_subscriptions"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    }
+  ],
+  "helpers": [
+    {
+      "name": "sendPushToHouse",
+      "file": "server/index.js",
+      "line": 1261,
+      "queries": [
+        {
+          "line": 1265,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT endpoint, keys_p256dh, keys_auth FROM push_subscriptions WHERE organization_id = $1",
+          "op": "SELECT",
+          "tables": [
+            "push_subscriptions"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1279,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "DELETE FROM push_subscriptions WHERE endpoint = $1",
+          "op": "DELETE",
+          "tables": [
+            "push_subscriptions"
+          ],
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    {
+      "name": "migrate",
+      "file": "server/index.js",
+      "line": 1291,
+      "queries": [
+        {
+          "line": 1294,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE TABLE IF NOT EXISTS tasks (\n        id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        name        TEXT NOT NULL,\n        description TEXT,\n        frequency_type  TEXT NOT NULL CHECK (frequency_type IN ('daily', 'weekly', 'biweekly', 'monthly')),\n        frequency_value INTEGER NOT NULL DEFAULT 1,\n        is_active   BOOLEAN NOT NULL DEFAULT true,\n        product_name  TEXT,\n        product_image TEXT,\n        organization_id TEXT,\n        created_at  TIMESTAMPTZ DEFAULT NOW()\n      )",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1309,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE TABLE IF NOT EXISTS completions (\n        id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        task_id     UUID NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,\n        completed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n        completed_by TEXT,\n        user_id TEXT\n      )",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1318,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_completions_task_id ON completions(task_id)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1319,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_completions_completed_at ON completions(completed_at DESC)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1321,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE TABLE IF NOT EXISTS products (\n        id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        name            TEXT NOT NULL,\n        category        TEXT NOT NULL DEFAULT 'general',\n        is_out_of_stock BOOLEAN NOT NULL DEFAULT false,\n        reminder_frequency_days INTEGER NOT NULL DEFAULT 30,\n        last_purchased_at TIMESTAMPTZ,\n        organization_id TEXT,\n        created_at      TIMESTAMPTZ DEFAULT NOW()\n      )",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1333,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_products_category ON products(category)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1334,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_products_out_of_stock ON products(is_out_of_stock)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1336,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE TABLE IF NOT EXISTS shopping_categories (\n        id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        name            TEXT NOT NULL,\n        emoji           TEXT NOT NULL DEFAULT '📦',\n        sort_order      INTEGER NOT NULL DEFAULT 0,\n        organization_id TEXT NOT NULL,\n        created_at      TIMESTAMPTZ DEFAULT NOW()\n      )",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1346,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_categories_org ON shopping_categories(organization_id)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1348,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE TABLE IF NOT EXISTS shopping_items (\n        id           UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        name         TEXT NOT NULL,\n        note         TEXT,\n        added_by     TEXT,\n        is_purchased BOOLEAN NOT NULL DEFAULT false,\n        category_id  UUID REFERENCES shopping_categories(id) ON DELETE SET NULL,\n        organization_id TEXT,\n        created_at   TIMESTAMPTZ DEFAULT NOW()\n      )",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1360,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_purchased ON shopping_items(is_purchased)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1361,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_category ON shopping_items(category_id)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1383,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_tasks_org ON tasks(organization_id)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1384,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_products_org ON products(organization_id)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1385,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_org ON shopping_items(organization_id)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1389,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_category ON shopping_items(category_id)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1397,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_archived ON shopping_items(archived_at)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1398,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_purchased_at ON shopping_items(purchased_at DESC)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1401,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE TABLE IF NOT EXISTS house_member_profiles (\n        id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        user_id         TEXT NOT NULL,\n        organization_id TEXT NOT NULL,\n        avatar          TEXT NOT NULL DEFAULT '🧑',\n        color           TEXT NOT NULL DEFAULT '#6a9960',\n        home_screen     TEXT NOT NULL DEFAULT 'tasks',\n        created_at      TIMESTAMPTZ DEFAULT NOW(),\n        UNIQUE(user_id, organization_id)\n      )",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1415,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE TABLE IF NOT EXISTS super_admins (\n        id         UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        user_id    TEXT NOT NULL UNIQUE,\n        created_at TIMESTAMPTZ DEFAULT NOW()\n      )",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1424,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE TABLE IF NOT EXISTS plants (\n        id                       UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        name                     TEXT NOT NULL,\n        notes                    TEXT,\n        watering_frequency_days  INTEGER NOT NULL DEFAULT 7,\n        last_watered_at          TIMESTAMPTZ,\n        organization_id          TEXT NOT NULL,\n        created_at               TIMESTAMPTZ DEFAULT NOW()\n      )",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1435,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_plants_org ON plants(organization_id)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1437,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE TABLE IF NOT EXISTS plant_watering_history (\n        id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        plant_id    UUID NOT NULL REFERENCES plants(id) ON DELETE CASCADE,\n        watered_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n        watered_by  TEXT,\n        user_id     TEXT\n      )",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1446,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_plant_watering_plant_id ON plant_watering_history(plant_id)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1447,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_plant_watering_at ON plant_watering_history(watered_at DESC)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1450,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE TABLE IF NOT EXISTS push_subscriptions (\n        id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        user_id         TEXT NOT NULL,\n        organization_id TEXT NOT NULL,\n        endpoint        TEXT NOT NULL UNIQUE,\n        keys_p256dh     TEXT NOT NULL,\n        keys_auth       TEXT NOT NULL,\n        created_at      TIMESTAMPTZ DEFAULT NOW(),\n        updated_at      TIMESTAMPTZ DEFAULT NOW()\n      )",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1462,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_push_subs_org ON push_subscriptions(organization_id)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1463,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_push_subs_user ON push_subscriptions(user_id)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    {
+      "name": "addColumnIfMissing",
+      "file": "server/index.js",
+      "line": 1471,
+      "queries": [
+        {
+          "line": 1472,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT column_name FROM information_schema.columns\n    WHERE table_name = $1 AND column_name = $2",
+          "op": "SELECT",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 1477,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "ALTER TABLE ${table} ADD COLUMN ${column} ${type}",
+          "op": "ALTER",
+          "tables": [],
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    {
+      "name": "requireHouse",
+      "file": "server/lib/middleware.js",
+      "line": 42,
+      "queries": [
+        {
+          "line": 47,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT * FROM \"member\" WHERE \"userId\" = $1 AND \"organizationId\" = $2",
+          "op": "SELECT",
+          "tables": [
+            "member"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "name": "requireSuperAdmin",
+      "file": "server/lib/middleware.js",
+      "line": 66,
+      "queries": [
+        {
+          "line": 68,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT id FROM super_admins WHERE user_id = $1",
+          "op": "SELECT",
+          "tables": [
+            "super_admins"
+          ],
+          "filtersByOrgId": false
+        }
+      ]
+    }
+  ],
+  "tableIndex": {
+    "tasks": {
+      "defined": true,
+      "schema": {
+        "columns": [
+          {
+            "name": "id",
+            "type": "UUID"
+          },
+          {
+            "name": "name",
+            "type": "TEXT"
+          },
+          {
+            "name": "description",
+            "type": "TEXT"
+          },
+          {
+            "name": "frequency_type",
+            "type": "TEXT"
+          },
+          {
+            "name": "frequency_value",
+            "type": "INTEGER"
+          },
+          {
+            "name": "is_active",
+            "type": "BOOLEAN"
+          },
+          {
+            "name": "product_name",
+            "type": "TEXT"
+          },
+          {
+            "name": "product_image",
+            "type": "TEXT"
+          },
+          {
+            "name": "organization_id",
+            "type": "TEXT"
+          },
+          {
+            "name": "last_reset_at",
+            "type": "TIMESTAMPTZ"
+          },
+          {
+            "name": "created_at",
+            "type": "TIMESTAMPTZ"
+          }
+        ],
+        "fks": [],
+        "hasOrgId": true,
+        "source": "db/init.sql"
+      },
+      "readers": [
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/super-admin/stats",
+          "file": "server/index.js",
+          "line": 107,
+          "op": "SELECT",
+          "filtersByOrgId": false
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/super-admin/stats",
+          "file": "server/index.js",
+          "line": 116,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/houses/seed",
+          "file": "server/index.js",
+          "line": 332,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/tasks/pending",
+          "file": "server/index.js",
+          "line": 503,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/tasks/:id",
+          "file": "server/index.js",
+          "line": 578,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/completions",
+          "file": "server/index.js",
+          "line": 598,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/completions",
+          "file": "server/index.js",
+          "line": 616,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/completions/:taskId/history",
+          "file": "server/index.js",
+          "line": 669,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/stats/participation",
+          "file": "server/index.js",
+          "line": 1129,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/stats/participation",
+          "file": "server/index.js",
+          "line": 1149,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/stats/participation",
+          "file": "server/index.js",
+          "line": 1162,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        }
+      ],
+      "writers": [
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/houses/:id",
+          "file": "server/index.js",
+          "line": 298,
+          "op": "DELETE",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/houses/seed",
+          "file": "server/index.js",
+          "line": 368,
+          "op": "INSERT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/houses/seed",
+          "file": "server/index.js",
+          "line": 404,
+          "op": "INSERT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/tasks",
+          "file": "server/index.js",
+          "line": 544,
+          "op": "INSERT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/tasks/:id",
+          "file": "server/index.js",
+          "line": 586,
+          "op": "DELETE",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/completions",
+          "file": "server/index.js",
+          "line": 628,
+          "op": "UPDATE",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/tasks/:id/reset",
+          "file": "server/index.js",
+          "line": 654,
+          "op": "UPDATE",
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    "completions": {
+      "defined": true,
+      "schema": {
+        "columns": [
+          {
+            "name": "id",
+            "type": "UUID"
+          },
+          {
+            "name": "task_id",
+            "type": "UUID"
+          },
+          {
+            "name": "completed_at",
+            "type": "TIMESTAMPTZ"
+          },
+          {
+            "name": "completed_by",
+            "type": "TEXT"
+          },
+          {
+            "name": "user_id",
+            "type": "TEXT"
+          }
+        ],
+        "fks": [
+          {
+            "column": "task_id",
+            "refTable": "tasks",
+            "refColumn": "id"
+          }
+        ],
+        "hasOrgId": false,
+        "source": "db/init.sql"
+      },
+      "readers": [
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/super-admin/stats",
+          "file": "server/index.js",
+          "line": 108,
+          "op": "SELECT",
+          "filtersByOrgId": false
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/super-admin/stats",
+          "file": "server/index.js",
+          "line": 109,
+          "op": "SELECT",
+          "filtersByOrgId": false
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/super-admin/stats",
+          "file": "server/index.js",
+          "line": 116,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/tasks/pending",
+          "file": "server/index.js",
+          "line": 503,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/completions",
+          "file": "server/index.js",
+          "line": 598,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/completions/:taskId/history",
+          "file": "server/index.js",
+          "line": 669,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/stats/participation",
+          "file": "server/index.js",
+          "line": 1129,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/stats/participation",
+          "file": "server/index.js",
+          "line": 1149,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/stats/participation",
+          "file": "server/index.js",
+          "line": 1162,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        }
+      ],
+      "writers": [
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/tasks/:id",
+          "file": "server/index.js",
+          "line": 585,
+          "op": "DELETE",
+          "filtersByOrgId": false
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/completions",
+          "file": "server/index.js",
+          "line": 621,
+          "op": "INSERT",
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    "products": {
+      "defined": true,
+      "schema": {
+        "columns": [
+          {
+            "name": "id",
+            "type": "UUID"
+          },
+          {
+            "name": "name",
+            "type": "TEXT"
+          },
+          {
+            "name": "category",
+            "type": "TEXT"
+          },
+          {
+            "name": "is_out_of_stock",
+            "type": "BOOLEAN"
+          },
+          {
+            "name": "reminder_frequency_days",
+            "type": "INTEGER"
+          },
+          {
+            "name": "units",
+            "type": "INTEGER"
+          },
+          {
+            "name": "last_purchased_at",
+            "type": "TIMESTAMPTZ"
+          },
+          {
+            "name": "last_out_of_stock_at",
+            "type": "TIMESTAMPTZ"
+          },
+          {
+            "name": "organization_id",
+            "type": "TEXT"
+          },
+          {
+            "name": "created_at",
+            "type": "TIMESTAMPTZ"
+          }
+        ],
+        "fks": [],
+        "hasOrgId": true,
+        "source": "db/init.sql"
+      },
+      "readers": [],
+      "writers": [
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/houses/:id",
+          "file": "server/index.js",
+          "line": 299,
+          "op": "DELETE",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/houses/seed",
+          "file": "server/index.js",
+          "line": 460,
+          "op": "INSERT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/products",
+          "file": "server/index.js",
+          "line": 712,
+          "op": "INSERT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/products/:id/purchase",
+          "file": "server/index.js",
+          "line": 752,
+          "op": "UPDATE",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/products/:id",
+          "file": "server/index.js",
+          "line": 769,
+          "op": "DELETE",
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    "shopping_categories": {
+      "defined": true,
+      "schema": {
+        "columns": [
+          {
+            "name": "id",
+            "type": "UUID"
+          },
+          {
+            "name": "name",
+            "type": "TEXT"
+          },
+          {
+            "name": "emoji",
+            "type": "TEXT"
+          },
+          {
+            "name": "sort_order",
+            "type": "INTEGER"
+          },
+          {
+            "name": "organization_id",
+            "type": "TEXT"
+          },
+          {
+            "name": "created_at",
+            "type": "TIMESTAMPTZ"
+          }
+        ],
+        "fks": [],
+        "hasOrgId": true,
+        "source": "db/init.sql"
+      },
+      "readers": [
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/shopping-categories",
+          "file": "server/index.js",
+          "line": 781,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/shopping-categories",
+          "file": "server/index.js",
+          "line": 797,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/shopping-items",
+          "file": "server/index.js",
+          "line": 858,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/shopping-items/history",
+          "file": "server/index.js",
+          "line": 942,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/shopping-items/recommendations",
+          "file": "server/index.js",
+          "line": 960,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        }
+      ],
+      "writers": [
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/houses/:id",
+          "file": "server/index.js",
+          "line": 301,
+          "op": "DELETE",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/shopping-categories",
+          "file": "server/index.js",
+          "line": 801,
+          "op": "INSERT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/shopping-categories/:id",
+          "file": "server/index.js",
+          "line": 834,
+          "op": "DELETE",
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    "shopping_items": {
+      "defined": true,
+      "schema": {
+        "columns": [
+          {
+            "name": "id",
+            "type": "UUID"
+          },
+          {
+            "name": "name",
+            "type": "TEXT"
+          },
+          {
+            "name": "note",
+            "type": "TEXT"
+          },
+          {
+            "name": "added_by",
+            "type": "TEXT"
+          },
+          {
+            "name": "is_purchased",
+            "type": "BOOLEAN"
+          },
+          {
+            "name": "category_id",
+            "type": "UUID"
+          },
+          {
+            "name": "organization_id",
+            "type": "TEXT"
+          },
+          {
+            "name": "purchased_at",
+            "type": "TIMESTAMPTZ"
+          },
+          {
+            "name": "archived_at",
+            "type": "TIMESTAMPTZ"
+          },
+          {
+            "name": "created_at",
+            "type": "TIMESTAMPTZ"
+          }
+        ],
+        "fks": [
+          {
+            "column": "category_id",
+            "refTable": "shopping_categories",
+            "refColumn": "id"
+          }
+        ],
+        "hasOrgId": true,
+        "source": "db/init.sql"
+      },
+      "readers": [
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/shopping-items",
+          "file": "server/index.js",
+          "line": 858,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/shopping-items/history",
+          "file": "server/index.js",
+          "line": 942,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/shopping-items/recommendations",
+          "file": "server/index.js",
+          "line": 960,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/shopping-items/recommendations",
+          "file": "server/index.js",
+          "line": 971,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        }
+      ],
+      "writers": [
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/houses/:id",
+          "file": "server/index.js",
+          "line": 300,
+          "op": "DELETE",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/shopping-items",
+          "file": "server/index.js",
+          "line": 847,
+          "op": "UPDATE",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/shopping-items",
+          "file": "server/index.js",
+          "line": 876,
+          "op": "INSERT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/shopping-items/clear-purchased",
+          "file": "server/index.js",
+          "line": 922,
+          "op": "UPDATE",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/shopping-items/:id",
+          "file": "server/index.js",
+          "line": 988,
+          "op": "DELETE",
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    "house_member_profiles": {
+      "defined": true,
+      "schema": {
+        "columns": [
+          {
+            "name": "id",
+            "type": "UUID"
+          },
+          {
+            "name": "user_id",
+            "type": "TEXT"
+          },
+          {
+            "name": "organization_id",
+            "type": "TEXT"
+          },
+          {
+            "name": "avatar",
+            "type": "TEXT"
+          },
+          {
+            "name": "color",
+            "type": "TEXT"
+          },
+          {
+            "name": "home_screen",
+            "type": "TEXT"
+          },
+          {
+            "name": "created_at",
+            "type": "TIMESTAMPTZ"
+          }
+        ],
+        "fks": [],
+        "hasOrgId": true,
+        "source": "db/init.sql"
+      },
+      "readers": [
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/houses/members",
+          "file": "server/index.js",
+          "line": 160,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/houses/profile",
+          "file": "server/index.js",
+          "line": 182,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "PUT",
+          "path": "/api/houses/profile",
+          "file": "server/index.js",
+          "line": 204,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/stats/participation",
+          "file": "server/index.js",
+          "line": 1129,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        }
+      ],
+      "writers": [
+        {
+          "kind": "route",
+          "method": "PUT",
+          "path": "/api/houses/profile",
+          "file": "server/index.js",
+          "line": 212,
+          "op": "INSERT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/houses/:id",
+          "file": "server/index.js",
+          "line": 302,
+          "op": "DELETE",
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    "super_admins": {
+      "defined": true,
+      "schema": {
+        "columns": [
+          {
+            "name": "id",
+            "type": "UUID"
+          },
+          {
+            "name": "user_id",
+            "type": "TEXT"
+          },
+          {
+            "name": "created_at",
+            "type": "TIMESTAMPTZ"
+          }
+        ],
+        "fks": [],
+        "hasOrgId": false,
+        "source": "db/init.sql"
+      },
+      "readers": [
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/super-admin/check",
+          "file": "server/index.js",
+          "line": 90,
+          "op": "SELECT",
+          "filtersByOrgId": false
+        },
+        {
+          "kind": "helper",
+          "helper": "requireSuperAdmin",
+          "file": "server/lib/middleware.js",
+          "line": 68,
+          "op": "SELECT",
+          "filtersByOrgId": false
+        }
+      ],
+      "writers": []
+    },
+    "plants": {
+      "defined": true,
+      "schema": {
+        "columns": [
+          {
+            "name": "id",
+            "type": "UUID"
+          },
+          {
+            "name": "name",
+            "type": "TEXT"
+          },
+          {
+            "name": "notes",
+            "type": "TEXT"
+          },
+          {
+            "name": "watering_frequency_days",
+            "type": "INTEGER"
+          },
+          {
+            "name": "last_watered_at",
+            "type": "TIMESTAMPTZ"
+          },
+          {
+            "name": "organization_id",
+            "type": "TEXT"
+          },
+          {
+            "name": "created_at",
+            "type": "TIMESTAMPTZ"
+          }
+        ],
+        "fks": [],
+        "hasOrgId": true,
+        "source": "db/init.sql"
+      },
+      "readers": [
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/plants",
+          "file": "server/index.js",
+          "line": 1000,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/plants/:id/water",
+          "file": "server/index.js",
+          "line": 1067,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/plants/:id/history",
+          "file": "server/index.js",
+          "line": 1103,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        }
+      ],
+      "writers": [
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/houses/:id",
+          "file": "server/index.js",
+          "line": 304,
+          "op": "DELETE",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/houses/:id",
+          "file": "server/index.js",
+          "line": 308,
+          "op": "DELETE",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/plants",
+          "file": "server/index.js",
+          "line": 1016,
+          "op": "INSERT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "PATCH",
+          "path": "/api/plants/:id",
+          "file": "server/index.js",
+          "line": 1035,
+          "op": "UPDATE",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/plants/:id",
+          "file": "server/index.js",
+          "line": 1051,
+          "op": "DELETE",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/plants/:id/water",
+          "file": "server/index.js",
+          "line": 1078,
+          "op": "UPDATE",
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    "plant_watering_history": {
+      "defined": true,
+      "schema": {
+        "columns": [
+          {
+            "name": "id",
+            "type": "UUID"
+          },
+          {
+            "name": "plant_id",
+            "type": "UUID"
+          },
+          {
+            "name": "watered_at",
+            "type": "TIMESTAMPTZ"
+          },
+          {
+            "name": "watered_by",
+            "type": "TEXT"
+          },
+          {
+            "name": "user_id",
+            "type": "TEXT"
+          }
+        ],
+        "fks": [
+          {
+            "column": "plant_id",
+            "refTable": "plants",
+            "refColumn": "id"
+          }
+        ],
+        "hasOrgId": false,
+        "source": "db/init.sql"
+      },
+      "readers": [
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/plants/:id/history",
+          "file": "server/index.js",
+          "line": 1103,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        }
+      ],
+      "writers": [
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/houses/:id",
+          "file": "server/index.js",
+          "line": 304,
+          "op": "DELETE",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/plants/:id/water",
+          "file": "server/index.js",
+          "line": 1074,
+          "op": "INSERT",
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    "push_subscriptions": {
+      "defined": true,
+      "schema": {
+        "columns": [
+          {
+            "name": "id",
+            "type": "UUID"
+          },
+          {
+            "name": "user_id",
+            "type": "TEXT"
+          },
+          {
+            "name": "organization_id",
+            "type": "TEXT"
+          },
+          {
+            "name": "endpoint",
+            "type": "TEXT"
+          },
+          {
+            "name": "keys_p256dh",
+            "type": "TEXT"
+          },
+          {
+            "name": "keys_auth",
+            "type": "TEXT"
+          },
+          {
+            "name": "created_at",
+            "type": "TIMESTAMPTZ"
+          },
+          {
+            "name": "updated_at",
+            "type": "TIMESTAMPTZ"
+          }
+        ],
+        "fks": [],
+        "hasOrgId": true,
+        "source": "server/index.js:1450"
+      },
+      "readers": [
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/push/status",
+          "file": "server/index.js",
+          "line": 1250,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "helper",
+          "helper": "sendPushToHouse",
+          "file": "server/index.js",
+          "line": 1265,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        }
+      ],
+      "writers": [
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/houses/:id",
+          "file": "server/index.js",
+          "line": 303,
+          "op": "DELETE",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/push/subscribe",
+          "file": "server/index.js",
+          "line": 1218,
+          "op": "INSERT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/push/subscribe",
+          "file": "server/index.js",
+          "line": 1240,
+          "op": "DELETE",
+          "filtersByOrgId": false
+        },
+        {
+          "kind": "helper",
+          "helper": "sendPushToHouse",
+          "file": "server/index.js",
+          "line": 1279,
+          "op": "DELETE",
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    "user": {
+      "defined": false,
+      "schema": null,
+      "readers": [
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/super-admin/stats",
+          "file": "server/index.js",
+          "line": 104,
+          "op": "SELECT",
+          "filtersByOrgId": false
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/houses/members",
+          "file": "server/index.js",
+          "line": 160,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/invitations",
+          "file": "server/index.js",
+          "line": 228,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        }
+      ],
+      "writers": []
+    },
+    "organization": {
+      "defined": false,
+      "schema": null,
+      "readers": [
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/super-admin/stats",
+          "file": "server/index.js",
+          "line": 105,
+          "op": "SELECT",
+          "filtersByOrgId": false
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/super-admin/stats",
+          "file": "server/index.js",
+          "line": 116,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        }
+      ],
+      "writers": [
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/houses/:id",
+          "file": "server/index.js",
+          "line": 312,
+          "op": "DELETE",
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    "member": {
+      "defined": false,
+      "schema": null,
+      "readers": [
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/super-admin/stats",
+          "file": "server/index.js",
+          "line": 106,
+          "op": "SELECT",
+          "filtersByOrgId": false
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/super-admin/stats",
+          "file": "server/index.js",
+          "line": 116,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/houses/members",
+          "file": "server/index.js",
+          "line": 160,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/houses/:id",
+          "file": "server/index.js",
+          "line": 285,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "helper",
+          "helper": "requireHouse",
+          "file": "server/lib/middleware.js",
+          "line": 47,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        }
+      ],
+      "writers": [
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/houses/:id",
+          "file": "server/index.js",
+          "line": 311,
+          "op": "DELETE",
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    "invitation": {
+      "defined": false,
+      "schema": null,
+      "readers": [
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/invitations",
+          "file": "server/index.js",
+          "line": 228,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        }
+      ],
+      "writers": [
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/invitations/:id",
+          "file": "server/index.js",
+          "line": 245,
+          "op": "DELETE",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/invitations/:id/renew",
+          "file": "server/index.js",
+          "line": 261,
+          "op": "UPDATE",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/houses/:id",
+          "file": "server/index.js",
+          "line": 310,
+          "op": "DELETE",
+          "filtersByOrgId": true
+        }
+      ]
+    }
+  }
+}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,6 +4,13 @@
 
 set -e
 
+# Regenerar code graph si los staged tocan server/, schema o el script
+if git diff --cached --name-only --diff-filter=ACMR | grep -qE '^(server/|db/init\.sql$|scripts/codegraph\.js$)'; then
+  echo "→ Pre-commit: regenerando code graph"
+  npm run codegraph --silent
+  git add .claude/code-graph.json docs/CODE_GRAPH.md
+fi
+
 echo "→ Pre-commit: npm test (frontend + server)"
 npm test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,8 @@ Soy el **CEO técnico** de Casa Limpia. Mi trabajo es:
 | `docs/LINEAMIENTOS.md` | Principios de desarrollo y proceso |
 | `docs/CHANGELOG.md` | Registro de cambios por fase del roadmap |
 | `docs/PUSH_NOTIFICATIONS.md` | Arquitectura push notifications: flujo, endpoints, SW, triggers |
+| `docs/CODE_GRAPH.md` | Grafo auto-generado: rutas API → handler → SQL + índice inverso por tabla. Regenerar con `npm run codegraph` tras cambios en `server/` o `db/init.sql`. |
+| `.claude/code-graph.json` | Misma info en JSON estructurado, optimizado para que Claude lo consulte primero antes de hacer grep. |
 
 ## Reglas Críticas
 

--- a/docs/CODE_GRAPH.md
+++ b/docs/CODE_GRAPH.md
@@ -1,0 +1,529 @@
+# Code Graph — Casa Limpia
+
+_Generado automaticamente por `scripts/codegraph.js` el 2026-05-27T23:26:31.706Z._
+
+**No editar a mano.** Regenerar con `npm run codegraph` despues de cambios en `server/` o `db/init.sql`.
+
+## Resumen
+
+| Metrica | Valor |
+|---|---|
+| Rutas registradas | 50 |
+| Queries en rutas (estaticas) | 78 |
+| Queries dinamicas (SQL en variable) | 6 |
+| Queries con filtro `organization_id` | 59 |
+| Helpers con queries | 5 |
+| Tablas en schema | 10 |
+| Tablas referenciadas (incl. externas) | 14 |
+
+## Queries sin filtro multi-tenant (revisar)
+
+Queries que tocan tablas con `organization_id` pero no lo filtran:
+
+- `GET /api/super-admin/stats` (server/index.js:107) — SELECT `tasks`
+- `DELETE /api/push/subscribe` (server/index.js:1240) — DELETE `push_subscriptions`
+
+## API → Handler → SQL
+
+### /api/auth
+
+**`ALL /api/auth/*`** — server/index.js:79
+
+- _Sin queries directas._
+
+### /api/completions
+
+**`GET /api/completions`** — server/index.js:596 _[requireAuth, requireHouse]_
+
+- [OK] L598 SELECT → `completions, tasks`
+
+**`POST /api/completions`** — server/index.js:612 _[requireAuth, requireHouse]_
+
+- [OK] L616 SELECT → `tasks`
+-      L621 INSERT → `completions`
+- [OK] L628 UPDATE → `tasks`
+
+**`GET /api/completions/:taskId/history`** — server/index.js:666 _[requireAuth, requireHouse]_
+
+- [OK] L669 SELECT → `completions, tasks`
+
+### /api/health
+
+**`GET /api/health`** — server/index.js:473
+
+-      L475 SELECT
+
+### /api/houses
+
+**`GET /api/houses/members`** — server/index.js:158 _[requireAuth, requireHouse]_
+
+- [OK] L160 SELECT → `member, user, house_member_profiles`
+
+**`GET /api/houses/profile`** — server/index.js:180 _[requireAuth, requireHouse]_
+
+- [OK] L182 SELECT → `house_member_profiles`
+
+**`PUT /api/houses/profile`** — server/index.js:198 _[requireAuth, requireHouse]_
+
+- [OK] L204 SELECT → `house_member_profiles`
+- [OK] L212 INSERT → `house_member_profiles`
+
+**`DELETE /api/houses/:id`** — server/index.js:278 _[requireAuth]_
+
+-      L285 SELECT → `member`
+-      L296 BEGIN
+- [OK] L298 DELETE → `tasks`
+- [OK] L299 DELETE → `products`
+- [OK] L300 DELETE → `shopping_items`
+- [OK] L301 DELETE → `shopping_categories`
+- [OK] L302 DELETE → `house_member_profiles`
+- [OK] L303 DELETE → `push_subscriptions`
+- [OK] L304 DELETE → `plant_watering_history, plants`
+- [OK] L308 DELETE → `plants`
+-      L310 DELETE → `invitation`
+-      L311 DELETE → `member`
+-      L312 DELETE → `organization`
+-      L313 COMMIT
+-      L317 ROLLBACK
+
+**`POST /api/houses/seed`** — server/index.js:325 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+
+- [OK] L332 SELECT → `tasks`
+- [OK] L368 INSERT → `tasks`
+- [OK] L404 INSERT → `tasks`
+- [OK] L460 INSERT → `products`
+
+### /api/invitations
+
+**`GET /api/invitations`** — server/index.js:226 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+
+-      L228 SELECT → `invitation, user`
+
+**`DELETE /api/invitations/:id`** — server/index.js:243 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+
+-      L245 DELETE → `invitation`
+
+**`POST /api/invitations/:id/renew`** — server/index.js:259 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+
+-      L261 UPDATE → `invitation`
+
+### /api/plants
+
+**`GET /api/plants`** — server/index.js:998 _[requireAuth, requireHouse]_
+
+- [OK] L1000 SELECT → `plants`
+
+**`POST /api/plants`** — server/index.js:1011 _[requireAuth, requireHouse]_
+
+- [OK] L1016 INSERT → `plants`
+
+**`PATCH /api/plants/:id`** — server/index.js:1028 _[requireAuth, requireHouse]_
+
+- [OK] L1035 UPDATE → `plants`
+
+**`DELETE /api/plants/:id`** — server/index.js:1048 _[requireAuth, requireHouse]_
+
+- [OK] L1051 DELETE → `plants`
+
+**`POST /api/plants/:id/water`** — server/index.js:1063 _[requireAuth, requireHouse]_
+
+- [OK] L1067 SELECT → `plants`
+-      L1073 BEGIN
+-      L1074 INSERT → `plant_watering_history`
+- [OK] L1078 UPDATE → `plants`
+-      L1082 COMMIT
+-      L1092 ROLLBACK
+
+**`GET /api/plants/:id/history`** — server/index.js:1100 _[requireAuth, requireHouse]_
+
+- [OK] L1103 SELECT → `plant_watering_history, plants`
+
+### /api/products
+
+**`GET /api/products`** — server/index.js:684 _[requireAuth, requireHouse]_
+
+- L700 _dynamic SQL (`pool.query(variable)`)_
+
+**`POST /api/products`** — server/index.js:708 _[requireAuth, requireHouse]_
+
+- [OK] L712 INSERT → `products`
+
+**`PATCH /api/products/:id`** — server/index.js:724 _[requireAuth, requireHouse]_
+
+- L740 _dynamic SQL (`pool.query(variable)`)_
+
+**`POST /api/products/:id/purchase`** — server/index.js:749 _[requireAuth, requireHouse]_
+
+- [OK] L752 UPDATE → `products`
+
+**`DELETE /api/products/:id`** — server/index.js:766 _[requireAuth, requireHouse]_
+
+- [OK] L769 DELETE → `products`
+
+### /api/push
+
+**`GET /api/push/vapid-key`** — server/index.js:1204
+
+- _Sin queries directas._
+
+**`POST /api/push/subscribe`** — server/index.js:1211 _[requireAuth, requireHouse]_
+
+- [OK] L1218 INSERT → `push_subscriptions`
+
+**`DELETE /api/push/subscribe`** — server/index.js:1236 _[requireAuth]_
+
+- [!!] L1240 DELETE → `push_subscriptions`
+
+**`GET /api/push/status`** — server/index.js:1248 _[requireAuth, requireHouse]_
+
+- [OK] L1250 SELECT → `push_subscriptions`
+
+### /api/shopping-categories
+
+**`GET /api/shopping-categories`** — server/index.js:779 _[requireAuth, requireHouse]_
+
+- [OK] L781 SELECT → `shopping_categories`
+
+**`POST /api/shopping-categories`** — server/index.js:792 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+
+- [OK] L797 SELECT → `shopping_categories`
+- [OK] L801 INSERT → `shopping_categories`
+
+**`PATCH /api/shopping-categories/:id`** — server/index.js:812 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+
+- L822 _dynamic SQL (`pool.query(variable)`)_
+
+**`DELETE /api/shopping-categories/:id`** — server/index.js:831 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+
+- [OK] L834 DELETE → `shopping_categories`
+
+### /api/shopping-items
+
+**`GET /api/shopping-items`** — server/index.js:844 _[requireAuth, requireHouse]_
+
+- [OK] L847 UPDATE → `shopping_items`
+- [OK] L858 SELECT → `shopping_items, shopping_categories`
+
+**`POST /api/shopping-items`** — server/index.js:872 _[requireAuth, requireHouse]_
+
+- [OK] L876 INSERT → `shopping_items`
+
+**`PATCH /api/shopping-items/:id`** — server/index.js:887 _[requireAuth, requireHouse]_
+
+- L909 _dynamic SQL (`pool.query(variable)`)_
+
+**`DELETE /api/shopping-items/clear-purchased`** — server/index.js:919 _[requireAuth, requireHouse]_
+
+- [OK] L922 UPDATE → `shopping_items`
+
+**`GET /api/shopping-items/history`** — server/index.js:939 _[requireAuth, requireHouse]_
+
+- [OK] L942 SELECT → `shopping_items, shopping_categories`
+
+**`GET /api/shopping-items/recommendations`** — server/index.js:958 _[requireAuth, requireHouse]_
+
+- [OK] L960 SELECT → `shopping_items, shopping_categories`
+- [OK] L971 SELECT → `shopping_items`
+
+**`DELETE /api/shopping-items/:id`** — server/index.js:985 _[requireAuth, requireHouse]_
+
+- [OK] L988 DELETE → `shopping_items`
+
+### /api/stats
+
+**`GET /api/stats/participation`** — server/index.js:1118 _[requireAuth, requireHouse]_
+
+- [OK] L1129 SELECT → `completions, tasks, house_member_profiles`
+- [OK] L1149 SELECT → `completions, tasks`
+- [OK] L1162 SELECT → `completions, tasks`
+
+### /api/super-admin
+
+**`GET /api/super-admin/check`** — server/index.js:88 _[requireAuth]_
+
+-      L90 SELECT → `super_admins`
+
+**`GET /api/super-admin/stats`** — server/index.js:101 _[requireAuth, requireSuperAdmin]_
+
+-      L104 SELECT → `user`
+-      L105 SELECT → `organization`
+-      L106 SELECT → `member`
+- [!!] L107 SELECT → `tasks`
+-      L108 SELECT → `completions`
+-      L109 SELECT → `completions`
+- [OK] L116 SELECT → `organization, member, tasks, completions`
+
+### /api/tasks
+
+**`GET /api/tasks/pending`** — server/index.js:501 _[requireAuth, requireHouse]_
+
+- [OK] L503 SELECT → `tasks, completions`
+
+**`GET /api/tasks`** — server/index.js:527 _[requireAuth, requireHouse]_
+
+- L533 _dynamic SQL (`pool.query(variable)`)_
+
+**`POST /api/tasks`** — server/index.js:541 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+
+- [OK] L544 INSERT → `tasks`
+
+**`PATCH /api/tasks/:id`** — server/index.js:556 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+
+- L566 _dynamic SQL (`pool.query(variable)`)_
+
+**`DELETE /api/tasks/:id`** — server/index.js:575 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+
+- [OK] L578 SELECT → `tasks`
+-      L585 DELETE → `completions`
+- [OK] L586 DELETE → `tasks`
+
+**`POST /api/tasks/:id/reset`** — server/index.js:651 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+
+- [OK] L654 UPDATE → `tasks`
+
+### /api/uploads
+
+**`POST /api/uploads`** — server/index.js:484 _[requireAuth, upload.single('image')]_
+
+- _Sin queries directas._
+
+**`DELETE /api/uploads/:filename`** — server/index.js:489 _[requireAuth]_
+
+- _Sin queries directas._
+
+## Helpers / factories con queries
+
+**`sendPushToHouse`** — server/index.js:1261
+
+- L1265 SELECT → `push_subscriptions` (filtra org)
+- L1279 DELETE → `push_subscriptions`
+
+**`migrate`** — server/index.js:1291
+
+- L1294 CREATE (filtra org)
+- L1309 CREATE
+- L1318 CREATE
+- L1319 CREATE
+- L1321 CREATE (filtra org)
+- L1333 CREATE
+- L1334 CREATE
+- L1336 CREATE (filtra org)
+- L1346 CREATE (filtra org)
+- L1348 CREATE (filtra org)
+- L1360 CREATE
+- L1361 CREATE
+- L1383 CREATE (filtra org)
+- L1384 CREATE (filtra org)
+- L1385 CREATE (filtra org)
+- L1389 CREATE
+- L1397 CREATE
+- L1398 CREATE
+- L1401 CREATE (filtra org)
+- L1415 CREATE
+- L1424 CREATE (filtra org)
+- L1435 CREATE (filtra org)
+- L1437 CREATE
+- L1446 CREATE
+- L1447 CREATE
+- L1450 CREATE (filtra org)
+- L1462 CREATE (filtra org)
+- L1463 CREATE
+
+**`addColumnIfMissing`** — server/index.js:1471
+
+- L1472 SELECT
+- L1477 ALTER
+
+**`requireHouse`** — server/lib/middleware.js:42
+
+- L47 SELECT → `member` (filtra org)
+
+**`requireSuperAdmin`** — server/lib/middleware.js:66
+
+- L68 SELECT → `super_admins`
+
+## Tablas → Endpoints
+
+### `completions`
+
+- **Columnas:** `id` UUID, `task_id` UUID, `completed_at` TIMESTAMPTZ, `completed_by` TEXT, `user_id` TEXT
+- **FK:** `task_id` → `tasks.id`
+- **Multi-tenant:** no
+- **Lectores (9):**
+    - `GET /api/super-admin/stats` (server/index.js:108, SELECT) [sin filtro org]
+    - `GET /api/super-admin/stats` (server/index.js:109, SELECT) [sin filtro org]
+    - `GET /api/super-admin/stats` (server/index.js:116, SELECT)
+    - `GET /api/tasks/pending` (server/index.js:503, SELECT)
+    - `GET /api/completions` (server/index.js:598, SELECT)
+    - `GET /api/completions/:taskId/history` (server/index.js:669, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1129, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1149, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1162, SELECT)
+- **Escritores (2):**
+    - `DELETE /api/tasks/:id` (server/index.js:585, DELETE) [sin filtro org]
+    - `POST /api/completions` (server/index.js:621, INSERT) [sin filtro org]
+
+### `house_member_profiles`
+
+- **Columnas:** `id` UUID, `user_id` TEXT, `organization_id` TEXT, `avatar` TEXT, `color` TEXT, `home_screen` TEXT, `created_at` TIMESTAMPTZ
+- **Multi-tenant:** si (organization_id)
+- **Lectores (4):**
+    - `GET /api/houses/members` (server/index.js:160, SELECT)
+    - `GET /api/houses/profile` (server/index.js:182, SELECT)
+    - `PUT /api/houses/profile` (server/index.js:204, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1129, SELECT)
+- **Escritores (2):**
+    - `PUT /api/houses/profile` (server/index.js:212, INSERT)
+    - `DELETE /api/houses/:id` (server/index.js:302, DELETE)
+
+### `invitation` _(externa — better-auth u otra fuente)_
+
+- **Lectores (1):**
+    - `GET /api/invitations` (server/index.js:228, SELECT)
+- **Escritores (3):**
+    - `DELETE /api/invitations/:id` (server/index.js:245, DELETE)
+    - `POST /api/invitations/:id/renew` (server/index.js:261, UPDATE)
+    - `DELETE /api/houses/:id` (server/index.js:310, DELETE)
+
+### `member` _(externa — better-auth u otra fuente)_
+
+- **Lectores (5):**
+    - `GET /api/super-admin/stats` (server/index.js:106, SELECT) [sin filtro org]
+    - `GET /api/super-admin/stats` (server/index.js:116, SELECT)
+    - `GET /api/houses/members` (server/index.js:160, SELECT)
+    - `DELETE /api/houses/:id` (server/index.js:285, SELECT)
+    - helper `requireHouse` (server/lib/middleware.js:47, SELECT)
+- **Escritores (1):**
+    - `DELETE /api/houses/:id` (server/index.js:311, DELETE)
+
+### `organization` _(externa — better-auth u otra fuente)_
+
+- **Lectores (2):**
+    - `GET /api/super-admin/stats` (server/index.js:105, SELECT) [sin filtro org]
+    - `GET /api/super-admin/stats` (server/index.js:116, SELECT)
+- **Escritores (1):**
+    - `DELETE /api/houses/:id` (server/index.js:312, DELETE) [sin filtro org]
+
+### `plant_watering_history`
+
+- **Columnas:** `id` UUID, `plant_id` UUID, `watered_at` TIMESTAMPTZ, `watered_by` TEXT, `user_id` TEXT
+- **FK:** `plant_id` → `plants.id`
+- **Multi-tenant:** no
+- **Lectores (1):**
+    - `GET /api/plants/:id/history` (server/index.js:1103, SELECT)
+- **Escritores (2):**
+    - `DELETE /api/houses/:id` (server/index.js:304, DELETE)
+    - `POST /api/plants/:id/water` (server/index.js:1074, INSERT) [sin filtro org]
+
+### `plants`
+
+- **Columnas:** `id` UUID, `name` TEXT, `notes` TEXT, `watering_frequency_days` INTEGER, `last_watered_at` TIMESTAMPTZ, `organization_id` TEXT, `created_at` TIMESTAMPTZ
+- **Multi-tenant:** si (organization_id)
+- **Lectores (3):**
+    - `GET /api/plants` (server/index.js:1000, SELECT)
+    - `POST /api/plants/:id/water` (server/index.js:1067, SELECT)
+    - `GET /api/plants/:id/history` (server/index.js:1103, SELECT)
+- **Escritores (6):**
+    - `DELETE /api/houses/:id` (server/index.js:304, DELETE)
+    - `DELETE /api/houses/:id` (server/index.js:308, DELETE)
+    - `POST /api/plants` (server/index.js:1016, INSERT)
+    - `PATCH /api/plants/:id` (server/index.js:1035, UPDATE)
+    - `DELETE /api/plants/:id` (server/index.js:1051, DELETE)
+    - `POST /api/plants/:id/water` (server/index.js:1078, UPDATE)
+
+### `products`
+
+- **Columnas:** `id` UUID, `name` TEXT, `category` TEXT, `is_out_of_stock` BOOLEAN, `reminder_frequency_days` INTEGER, `units` INTEGER, `last_purchased_at` TIMESTAMPTZ, `last_out_of_stock_at` TIMESTAMPTZ, `organization_id` TEXT, `created_at` TIMESTAMPTZ
+- **Multi-tenant:** si (organization_id)
+- **Escritores (5):**
+    - `DELETE /api/houses/:id` (server/index.js:299, DELETE)
+    - `POST /api/houses/seed` (server/index.js:460, INSERT)
+    - `POST /api/products` (server/index.js:712, INSERT)
+    - `POST /api/products/:id/purchase` (server/index.js:752, UPDATE)
+    - `DELETE /api/products/:id` (server/index.js:769, DELETE)
+
+### `push_subscriptions`
+
+- **Columnas:** `id` UUID, `user_id` TEXT, `organization_id` TEXT, `endpoint` TEXT, `keys_p256dh` TEXT, `keys_auth` TEXT, `created_at` TIMESTAMPTZ, `updated_at` TIMESTAMPTZ
+- **Multi-tenant:** si (organization_id)
+- **Lectores (2):**
+    - `GET /api/push/status` (server/index.js:1250, SELECT)
+    - helper `sendPushToHouse` (server/index.js:1265, SELECT)
+- **Escritores (4):**
+    - `DELETE /api/houses/:id` (server/index.js:303, DELETE)
+    - `POST /api/push/subscribe` (server/index.js:1218, INSERT)
+    - `DELETE /api/push/subscribe` (server/index.js:1240, DELETE) [sin filtro org]
+    - helper `sendPushToHouse` (server/index.js:1279, DELETE) [sin filtro org]
+
+### `shopping_categories`
+
+- **Columnas:** `id` UUID, `name` TEXT, `emoji` TEXT, `sort_order` INTEGER, `organization_id` TEXT, `created_at` TIMESTAMPTZ
+- **Multi-tenant:** si (organization_id)
+- **Lectores (5):**
+    - `GET /api/shopping-categories` (server/index.js:781, SELECT)
+    - `POST /api/shopping-categories` (server/index.js:797, SELECT)
+    - `GET /api/shopping-items` (server/index.js:858, SELECT)
+    - `GET /api/shopping-items/history` (server/index.js:942, SELECT)
+    - `GET /api/shopping-items/recommendations` (server/index.js:960, SELECT)
+- **Escritores (3):**
+    - `DELETE /api/houses/:id` (server/index.js:301, DELETE)
+    - `POST /api/shopping-categories` (server/index.js:801, INSERT)
+    - `DELETE /api/shopping-categories/:id` (server/index.js:834, DELETE)
+
+### `shopping_items`
+
+- **Columnas:** `id` UUID, `name` TEXT, `note` TEXT, `added_by` TEXT, `is_purchased` BOOLEAN, `category_id` UUID, `organization_id` TEXT, `purchased_at` TIMESTAMPTZ, `archived_at` TIMESTAMPTZ, `created_at` TIMESTAMPTZ
+- **FK:** `category_id` → `shopping_categories.id`
+- **Multi-tenant:** si (organization_id)
+- **Lectores (4):**
+    - `GET /api/shopping-items` (server/index.js:858, SELECT)
+    - `GET /api/shopping-items/history` (server/index.js:942, SELECT)
+    - `GET /api/shopping-items/recommendations` (server/index.js:960, SELECT)
+    - `GET /api/shopping-items/recommendations` (server/index.js:971, SELECT)
+- **Escritores (5):**
+    - `DELETE /api/houses/:id` (server/index.js:300, DELETE)
+    - `GET /api/shopping-items` (server/index.js:847, UPDATE)
+    - `POST /api/shopping-items` (server/index.js:876, INSERT)
+    - `DELETE /api/shopping-items/clear-purchased` (server/index.js:922, UPDATE)
+    - `DELETE /api/shopping-items/:id` (server/index.js:988, DELETE)
+
+### `super_admins`
+
+- **Columnas:** `id` UUID, `user_id` TEXT, `created_at` TIMESTAMPTZ
+- **Multi-tenant:** no
+- **Lectores (2):**
+    - `GET /api/super-admin/check` (server/index.js:90, SELECT) [sin filtro org]
+    - helper `requireSuperAdmin` (server/lib/middleware.js:68, SELECT) [sin filtro org]
+
+### `tasks`
+
+- **Columnas:** `id` UUID, `name` TEXT, `description` TEXT, `frequency_type` TEXT, `frequency_value` INTEGER, `is_active` BOOLEAN, `product_name` TEXT, `product_image` TEXT, `organization_id` TEXT, `last_reset_at` TIMESTAMPTZ, `created_at` TIMESTAMPTZ
+- **Multi-tenant:** si (organization_id)
+- **Lectores (11):**
+    - `GET /api/super-admin/stats` (server/index.js:107, SELECT) [sin filtro org]
+    - `GET /api/super-admin/stats` (server/index.js:116, SELECT)
+    - `POST /api/houses/seed` (server/index.js:332, SELECT)
+    - `GET /api/tasks/pending` (server/index.js:503, SELECT)
+    - `DELETE /api/tasks/:id` (server/index.js:578, SELECT)
+    - `GET /api/completions` (server/index.js:598, SELECT)
+    - `POST /api/completions` (server/index.js:616, SELECT)
+    - `GET /api/completions/:taskId/history` (server/index.js:669, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1129, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1149, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1162, SELECT)
+- **Escritores (7):**
+    - `DELETE /api/houses/:id` (server/index.js:298, DELETE)
+    - `POST /api/houses/seed` (server/index.js:368, INSERT)
+    - `POST /api/houses/seed` (server/index.js:404, INSERT)
+    - `POST /api/tasks` (server/index.js:544, INSERT)
+    - `DELETE /api/tasks/:id` (server/index.js:586, DELETE)
+    - `POST /api/completions` (server/index.js:628, UPDATE)
+    - `POST /api/tasks/:id/reset` (server/index.js:654, UPDATE)
+
+### `user` _(externa — better-auth u otra fuente)_
+
+- **Lectores (3):**
+    - `GET /api/super-admin/stats` (server/index.js:104, SELECT) [sin filtro org]
+    - `GET /api/houses/members` (server/index.js:160, SELECT)
+    - `GET /api/invitations` (server/index.js:228, SELECT)
+

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "casa-limpia-root",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "description": "Orquestacion de scripts y hooks para frontend + server",
   "scripts": {
     "install:all": "npm --prefix frontend install && npm --prefix server install",
@@ -9,6 +10,7 @@
     "test:coverage": "npm --prefix server run test:coverage && npm --prefix frontend run test:coverage",
     "build": "npm --prefix frontend run build",
     "ci": "npm test && npm run build",
+    "codegraph": "node scripts/codegraph.js",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/scripts/codegraph.js
+++ b/scripts/codegraph.js
@@ -1,0 +1,701 @@
+#!/usr/bin/env node
+// scripts/codegraph.js
+// Escanea el servidor (rutas, middlewares, queries) y el schema (db/init.sql)
+// y genera un grafo: API -> Handler -> SQL + indice inverso Tabla -> Endpoints.
+//
+// Salidas:
+//   .claude/code-graph.json  (estructurado, para Claude)
+//   docs/CODE_GRAPH.md       (legible, con tabla de violaciones multi-tenant)
+//
+// Uso: npm run codegraph
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, '..')
+
+// ---------- IO helpers ----------
+function readFile(p) {
+  return fs.readFileSync(p, 'utf8')
+}
+
+function writeFile(p, content) {
+  fs.mkdirSync(path.dirname(p), { recursive: true })
+  fs.writeFileSync(p, content)
+}
+
+function lineOf(src, pos) {
+  let line = 1
+  for (let i = 0; i < pos && i < src.length; i++) if (src[i] === '\n') line++
+  return line
+}
+
+// ---------- Source masking ----------
+// Devuelve una copia del codigo donde el contenido de strings y comentarios
+// se reemplaza por espacios/saltos de linea, preservando posiciones.
+// Asi podemos correr regex sobre las posiciones sin matchear texto dentro de
+// strings o comentarios.
+function maskSource(src) {
+  const out = new Array(src.length).fill(' ')
+  const blank = (i) => { out[i] = src[i] === '\n' ? '\n' : ' ' }
+  let i = 0
+  while (i < src.length) {
+    const c = src[i]
+    const n = src[i + 1]
+    if (c === '/' && n === '/') {
+      while (i < src.length && src[i] !== '\n') { blank(i); i++ }
+      continue
+    }
+    if (c === '/' && n === '*') {
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) { blank(i); i++ }
+      if (i < src.length) { blank(i); blank(i + 1); i += 2 }
+      continue
+    }
+    if (c === "'" || c === '"') {
+      out[i] = c; i++
+      while (i < src.length) {
+        if (src[i] === '\\') { blank(i); if (i + 1 < src.length) blank(i + 1); i += 2; continue }
+        if (src[i] === c) { out[i] = c; i++; break }
+        blank(i); i++
+      }
+      continue
+    }
+    if (c === '`') {
+      out[i] = '`'; i++
+      while (i < src.length) {
+        if (src[i] === '\\') { blank(i); if (i + 1 < src.length) blank(i + 1); i += 2; continue }
+        if (src[i] === '`') { out[i] = '`'; i++; break }
+        if (src[i] === '$' && src[i + 1] === '{') {
+          out[i] = '$'; out[i + 1] = '{'; i += 2
+          let depth = 1
+          while (i < src.length && depth > 0) {
+            const cc = src[i]
+            if (cc === '"' || cc === "'") {
+              out[i] = cc; i++
+              while (i < src.length) {
+                if (src[i] === '\\') { blank(i); if (i + 1 < src.length) blank(i + 1); i += 2; continue }
+                if (src[i] === cc) { out[i] = cc; i++; break }
+                blank(i); i++
+              }
+              continue
+            }
+            if (cc === '{') { depth++; out[i] = '{'; i++; continue }
+            if (cc === '}') {
+              depth--
+              out[i] = '}'; i++
+              if (depth === 0) break
+              continue
+            }
+            out[i] = cc; i++
+          }
+          continue
+        }
+        blank(i); i++
+      }
+      continue
+    }
+    out[i] = c; i++
+  }
+  return out.join('')
+}
+
+function findMatching(masked, openPos, openCh, closeCh) {
+  let depth = 0
+  for (let i = openPos; i < masked.length; i++) {
+    if (masked[i] === openCh) depth++
+    else if (masked[i] === closeCh) {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return -1
+}
+
+function splitArgs(masked, openParen, closeParen) {
+  const result = []
+  let start = openParen + 1
+  let depth = 0
+  for (let i = openParen + 1; i < closeParen; i++) {
+    const c = masked[i]
+    if (c === '(' || c === '[' || c === '{') depth++
+    else if (c === ')' || c === ']' || c === '}') depth--
+    else if (c === ',' && depth === 0) {
+      result.push({ start, end: i })
+      start = i + 1
+    }
+  }
+  result.push({ start, end: closeParen })
+  return result
+}
+
+function findFirstQuote(masked, start, end) {
+  for (let i = start; i < end; i++) {
+    const c = masked[i]
+    if (c === "'" || c === '"' || c === '`') return i
+  }
+  return -1
+}
+
+function extractStringAt(src, masked, quotePos) {
+  const q = masked[quotePos]
+  if (q !== "'" && q !== '"' && q !== '`') return null
+  for (let i = quotePos + 1; i < masked.length; i++) {
+    if (masked[i] === q) return src.slice(quotePos + 1, i)
+  }
+  return null
+}
+
+// ---------- Schema parsing ----------
+const SQL_TYPES = /^(UUID|TEXT|INTEGER|BOOLEAN|TIMESTAMPTZ|TIMESTAMP|VARCHAR|BIGINT|JSONB|JSON|NUMERIC|DECIMAL|SERIAL|BIGSERIAL|DATE|TIME|SMALLINT|BYTEA|CHAR)/i
+
+function parseSchema(sql, into = {}, source = null) {
+  const tables = into
+  // Acepta tanto `\n);` (formato init.sql) como `\n      )` (CREATE inline en JS template)
+  const re = /CREATE TABLE (?:IF NOT EXISTS )?(\w+)\s*\(([\s\S]*?)\n\s*\)/g
+  let m
+  while ((m = re.exec(sql))) {
+    const [, name, body] = m
+    const columns = []
+    const fks = []
+    const lines = body.split('\n').map(l => l.trim().replace(/,\s*$/, '')).filter(Boolean)
+    for (const line of lines) {
+      if (line.startsWith('--')) continue
+      if (/^(UNIQUE|PRIMARY|CHECK|FOREIGN|CONSTRAINT)\b/i.test(line)) continue
+      const colMatch = line.match(/^(\w+)\s+(\S+)/)
+      if (colMatch && SQL_TYPES.test(colMatch[2])) {
+        const col = colMatch[1]
+        const type = colMatch[2].replace(/,$/, '')
+        columns.push({ name: col, type })
+        const fk = line.match(/REFERENCES\s+(\w+)\s*\((\w+)\)/i)
+        if (fk) fks.push({ column: col, refTable: fk[1], refColumn: fk[2] })
+      }
+    }
+    if (!tables[name]) {
+      tables[name] = {
+        columns,
+        fks,
+        hasOrgId: columns.some(c => c.name === 'organization_id'),
+        source: source || 'db/init.sql',
+      }
+    }
+  }
+  return tables
+}
+
+// ---------- SQL analysis ----------
+const PG_SYSTEM_SCHEMAS = new Set(['information_schema', 'pg_catalog', 'pg_temp', 'pg_toast'])
+const SQL_KEYWORDS_NOT_TABLES = new Set(['SET', 'WHERE', 'AS', 'ON', 'SELECT', 'VALUES', 'TABLE', 'INDEX'])
+
+function analyzeSql(sql) {
+  const flat = sql.replace(/\s+/g, ' ').trim()
+  const opMatch = flat.match(/^(SELECT|INSERT|UPDATE|DELETE|BEGIN|COMMIT|ROLLBACK|WITH|DO|CREATE|DROP|ALTER|SET)\b/i)
+  const op = opMatch ? opMatch[1].toUpperCase() : 'OTHER'
+  const tables = new Set()
+  // Captura opcionalmente un prefijo de schema: information_schema.columns -> table = columns, schema = information_schema
+  const tRe = /(?:FROM|JOIN|INTO|UPDATE)\s+(?:("?[A-Za-z_][A-Za-z0-9_]*"?)\.)?("?[A-Za-z_][A-Za-z0-9_]*"?)/gi
+  let tm
+  while ((tm = tRe.exec(flat))) {
+    const schema = tm[1] ? tm[1].replace(/"/g, '') : null
+    const raw = tm[2].replace(/"/g, '')
+    if (SQL_KEYWORDS_NOT_TABLES.has(raw.toUpperCase())) continue
+    if (schema && PG_SYSTEM_SCHEMAS.has(schema.toLowerCase())) continue
+    tables.add(raw)
+  }
+  const filtersByOrgId = /\borganization_id\b/.test(flat) || /"organizationId"/.test(flat)
+  return { op, tables: [...tables], filtersByOrgId }
+}
+
+// ---------- Route extraction ----------
+const ROUTE_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'all']
+const QUERY_CLIENTS = ['pool', 'client', 'db', 'trx', 'tx']
+
+function extractQueriesInRange(src, masked, from, to) {
+  const queries = []
+  const re = new RegExp(`\\b(${QUERY_CLIENTS.join('|')})\\.query\\s*\\(`, 'g')
+  re.lastIndex = from
+  let m
+  while ((m = re.exec(masked)) && m.index < to) {
+    const openParen = m.index + m[0].length - 1
+    const closeParen = findMatching(masked, openParen, '(', ')')
+    if (closeParen === -1) continue
+    let cursor = openParen + 1
+    while (cursor < closeParen && /\s/.test(masked[cursor])) cursor++
+    const isString = masked[cursor] === "'" || masked[cursor] === '"' || masked[cursor] === '`'
+    if (!isString) {
+      // Query dinamica: SQL construido en una variable. Anotar sin tablas.
+      queries.push({
+        line: lineOf(src, m.index),
+        client: m[1],
+        dynamic: true,
+        sql: null,
+        op: 'DYNAMIC',
+        tables: [],
+        filtersByOrgId: false,
+      })
+      continue
+    }
+    const sql = extractStringAt(src, masked, cursor)
+    if (sql === null) continue
+    const meta = analyzeSql(sql)
+    queries.push({
+      line: lineOf(src, m.index),
+      client: m[1],
+      dynamic: false,
+      sql: sql.trim(),
+      ...meta,
+    })
+  }
+  return queries
+}
+
+function parseRoutes(src, masked, filePath) {
+  const routes = []
+  const bodyRanges = []
+  const re = new RegExp(`\\bapp\\.(${ROUTE_METHODS.join('|')})\\s*\\(`, 'g')
+  let m
+  while ((m = re.exec(masked))) {
+    const method = m[1].toUpperCase()
+    const openParen = m.index + m[0].length - 1
+    const closeParen = findMatching(masked, openParen, '(', ')')
+    if (closeParen === -1) continue
+
+    const args = splitArgs(masked, openParen, closeParen)
+    if (args.length === 0) continue
+
+    const pathQuote = findFirstQuote(masked, args[0].start, args[0].end)
+    if (pathQuote === -1) continue
+    const pathStr = extractStringAt(src, masked, pathQuote)
+    if (!pathStr || !pathStr.startsWith('/')) continue
+
+    const middlewareArgs = args.slice(1, -1)
+    const middlewares = middlewareArgs.map(a => src.slice(a.start, a.end).trim().replace(/\s+/g, ' ')).filter(Boolean)
+
+    const handler = args[args.length - 1]
+    let bodyOpen = -1
+    let depth = 0
+    for (let i = handler.start; i < handler.end; i++) {
+      const c = masked[i]
+      if (c === '(' || c === '[') depth++
+      else if (c === ')' || c === ']') depth--
+      else if (c === '{' && depth === 0) { bodyOpen = i; break }
+    }
+    let queries = []
+    if (bodyOpen !== -1) {
+      const bodyClose = findMatching(masked, bodyOpen, '{', '}')
+      if (bodyClose !== -1) {
+        queries = extractQueriesInRange(src, masked, bodyOpen, bodyClose)
+        bodyRanges.push([bodyOpen, bodyClose])
+      }
+    }
+
+    routes.push({
+      file: filePath,
+      method,
+      path: pathStr,
+      line: lineOf(src, m.index),
+      middlewares,
+      queries,
+    })
+  }
+  return { routes, bodyRanges }
+}
+
+// ---------- Helper / factory extraction ----------
+// Captura funciones nombradas (function NAME, const NAME = () => ...) en cualquier
+// nivel y extrae sus queries. Cada query se atribuye SOLO al cuerpo mas chico que
+// la contiene, evitando doble conteo cuando una factory envuelve a otra funcion.
+// Las queries que caen dentro de un handler de ruta (rango ya cubierto por
+// parseRoutes) se excluyen via `routeBodyRanges`.
+function parseHelpers(src, masked, filePath, routeBodyRanges = []) {
+  const candidates = []
+  const seen = new Set()
+  const addCandidate = (name, headerStart, bodyOpen) => {
+    if (bodyOpen === -1) return
+    const bodyClose = findMatching(masked, bodyOpen, '{', '}')
+    if (bodyClose === -1) return
+    const key = `${name}:${headerStart}:${bodyOpen}`
+    if (seen.has(key)) return
+    seen.add(key)
+    candidates.push({ name, headerStart, bodyOpen, bodyClose })
+  }
+
+  // 1) function NAME(...)  (con cualquier combo de export/async)
+  const fnRe = /\b(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(/g
+  let m
+  while ((m = fnRe.exec(masked))) {
+    const openParen = m.index + m[0].length - 1
+    const closeParen = findMatching(masked, openParen, '(', ')')
+    if (closeParen === -1) continue
+    let i = closeParen + 1
+    while (i < masked.length && /\s/.test(masked[i])) i++
+    if (masked[i] !== '{') continue
+    addCandidate(m[1], m.index, i)
+  }
+
+  // 2) const NAME = (...) => { ... }
+  const arrowRe = /\b(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?\(/g
+  while ((m = arrowRe.exec(masked))) {
+    const openParen = m.index + m[0].length - 1
+    const closeParen = findMatching(masked, openParen, '(', ')')
+    if (closeParen === -1) continue
+    let i = closeParen + 1
+    while (i < masked.length && /\s/.test(masked[i])) i++
+    if (masked[i] !== '=' || masked[i + 1] !== '>') continue
+    i += 2
+    while (i < masked.length && /\s/.test(masked[i])) i++
+    if (masked[i] !== '{') continue
+    addCandidate(m[1], m.index, i)
+  }
+
+  // Para cada query del archivo, encontrar la candidata mas chica que la contiene
+  const allQueries = extractQueriesInRange(src, masked, 0, masked.length)
+  const sorted = [...candidates].sort((a, b) => (a.bodyClose - a.bodyOpen) - (b.bodyClose - b.bodyOpen))
+  const byCandidate = new Map()
+  for (const q of allQueries) {
+    // Buscar query position usando line para localizar (aproximado pero suficiente)
+    // Mejor: extractQueriesInRange devuelve la linea; necesitamos posicion. Reconstruir:
+    // Solucion: usar la regex de nuevo para obtener posiciones, mapeando 1:1.
+  }
+  // Mejor enfoque: re-escanear queries con posiciones
+  const re = new RegExp(`\\b(${QUERY_CLIENTS.join('|')})\\.query\\s*\\(`, 'g')
+  let qm
+  while ((qm = re.exec(masked))) {
+    const pos = qm.index
+    // Skip si esta dentro de un handler de ruta
+    if (routeBodyRanges.some(([s, e]) => pos >= s && pos <= e)) continue
+    // Buscar la candidata mas chica que contiene pos
+    const owner = sorted.find(c => pos >= c.bodyOpen && pos <= c.bodyClose)
+    if (!owner) continue
+    if (!byCandidate.has(owner)) byCandidate.set(owner, [])
+    byCandidate.get(owner).push(pos)
+  }
+
+  const helpers = []
+  for (const cand of candidates) {
+    const positions = byCandidate.get(cand)
+    if (!positions || positions.length === 0) continue
+    // Re-extraer queries en el cuerpo y filtrar por posiciones asignadas
+    const allInBody = extractQueriesInRangeWithPos(src, masked, cand.bodyOpen, cand.bodyClose)
+    const queries = allInBody.filter(q => positions.includes(q.pos)).map(({ pos, ...rest }) => rest)
+    if (queries.length === 0) continue
+    helpers.push({
+      name: cand.name,
+      file: filePath,
+      line: lineOf(src, cand.headerStart),
+      queries,
+    })
+  }
+  return helpers
+}
+
+// Variante de extractQueriesInRange que incluye la posicion absoluta de cada query.
+function extractQueriesInRangeWithPos(src, masked, from, to) {
+  const queries = []
+  const re = new RegExp(`\\b(${QUERY_CLIENTS.join('|')})\\.query\\s*\\(`, 'g')
+  re.lastIndex = from
+  let m
+  while ((m = re.exec(masked)) && m.index < to) {
+    const pos = m.index
+    const openParen = pos + m[0].length - 1
+    const closeParen = findMatching(masked, openParen, '(', ')')
+    if (closeParen === -1) continue
+    let cursor = openParen + 1
+    while (cursor < closeParen && /\s/.test(masked[cursor])) cursor++
+    const isString = masked[cursor] === "'" || masked[cursor] === '"' || masked[cursor] === '`'
+    if (!isString) {
+      queries.push({
+        pos,
+        line: lineOf(src, pos),
+        client: m[1],
+        dynamic: true,
+        sql: null,
+        op: 'DYNAMIC',
+        tables: [],
+        filtersByOrgId: false,
+      })
+      continue
+    }
+    const sql = extractStringAt(src, masked, cursor)
+    if (sql === null) continue
+    const meta = analyzeSql(sql)
+    queries.push({
+      pos,
+      line: lineOf(src, pos),
+      client: m[1],
+      dynamic: false,
+      sql: sql.trim(),
+      ...meta,
+    })
+  }
+  return queries
+}
+
+// ---------- Inverted index ----------
+function buildTableIndex(routes, helpers, schema) {
+  const idx = {}
+  const ensure = (t) => {
+    if (!idx[t]) {
+      idx[t] = {
+        defined: t in schema,
+        schema: schema[t] || null,
+        readers: [],
+        writers: [],
+      }
+    }
+    return idx[t]
+  }
+  for (const name of Object.keys(schema)) ensure(name)
+
+  const isWrite = (op) => ['INSERT', 'UPDATE', 'DELETE'].includes(op)
+  const record = (table, op, ref) => {
+    const e = ensure(table)
+    if (isWrite(op)) e.writers.push(ref)
+    else e.readers.push(ref)
+  }
+
+  for (const r of routes) {
+    for (const q of r.queries) {
+      if (!q.tables.length) continue
+      const ref = {
+        kind: 'route',
+        method: r.method,
+        path: r.path,
+        file: r.file,
+        line: q.line,
+        op: q.op,
+        filtersByOrgId: q.filtersByOrgId,
+      }
+      for (const t of q.tables) record(t, q.op, ref)
+    }
+  }
+  for (const h of helpers) {
+    for (const q of h.queries) {
+      if (!q.tables.length) continue
+      const ref = {
+        kind: 'helper',
+        helper: h.name,
+        file: h.file,
+        line: q.line,
+        op: q.op,
+        filtersByOrgId: q.filtersByOrgId,
+      }
+      for (const t of q.tables) record(t, q.op, ref)
+    }
+  }
+  return idx
+}
+
+// ---------- Output ----------
+function basename(p) {
+  return p.split('/').pop()
+}
+
+function renderMarkdown(graph) {
+  const { routes, helpers, schema, tableIndex, generatedAt } = graph
+  const lines = []
+  lines.push('# Code Graph — Casa Limpia')
+  lines.push('')
+  lines.push(`_Generado automaticamente por \`scripts/codegraph.js\` el ${generatedAt}._`)
+  lines.push('')
+  lines.push('**No editar a mano.** Regenerar con `npm run codegraph` despues de cambios en `server/` o `db/init.sql`.')
+  lines.push('')
+
+  const totalQueries = routes.reduce((a, r) => a + r.queries.length, 0)
+  const orgGuarded = routes.flatMap(r => r.queries).filter(q => q.filtersByOrgId).length
+  const dynamicCount = routes.flatMap(r => r.queries).filter(q => q.dynamic).length
+
+  lines.push('## Resumen')
+  lines.push('')
+  lines.push(`| Metrica | Valor |`)
+  lines.push(`|---|---|`)
+  lines.push(`| Rutas registradas | ${routes.length} |`)
+  lines.push(`| Queries en rutas (estaticas) | ${totalQueries - dynamicCount} |`)
+  lines.push(`| Queries dinamicas (SQL en variable) | ${dynamicCount} |`)
+  lines.push(`| Queries con filtro \`organization_id\` | ${orgGuarded} |`)
+  lines.push(`| Helpers con queries | ${helpers.length} |`)
+  lines.push(`| Tablas en schema | ${Object.keys(schema).length} |`)
+  lines.push(`| Tablas referenciadas (incl. externas) | ${Object.keys(tableIndex).length} |`)
+  lines.push('')
+
+  // Multi-tenant warnings
+  const warnings = []
+  for (const r of routes) {
+    for (const q of r.queries) {
+      if (q.dynamic) continue
+      if (['BEGIN', 'COMMIT', 'ROLLBACK', 'SET'].includes(q.op)) continue
+      const orgTables = q.tables.filter(t => schema[t]?.hasOrgId)
+      if (orgTables.length > 0 && !q.filtersByOrgId) {
+        warnings.push({ r, q, orgTables })
+      }
+    }
+  }
+  if (warnings.length > 0) {
+    lines.push('## Queries sin filtro multi-tenant (revisar)')
+    lines.push('')
+    lines.push('Queries que tocan tablas con `organization_id` pero no lo filtran:')
+    lines.push('')
+    for (const { r, q, orgTables } of warnings) {
+      lines.push(`- \`${r.method} ${r.path}\` (${r.file}:${q.line}) — ${q.op} \`${orgTables.join(', ')}\``)
+    }
+    lines.push('')
+  }
+
+  // Routes grouped
+  lines.push('## API → Handler → SQL')
+  lines.push('')
+  const grouped = {}
+  for (const r of routes) {
+    const parts = r.path.split('/').filter(Boolean)
+    const key = parts[1] || parts[0] || 'misc'
+    grouped[key] ||= []
+    grouped[key].push(r)
+  }
+  for (const key of Object.keys(grouped).sort()) {
+    lines.push(`### /api/${key}`)
+    lines.push('')
+    for (const r of grouped[key]) {
+      const mw = r.middlewares.length ? ` _[${r.middlewares.join(', ')}]_` : ''
+      lines.push(`**\`${r.method} ${r.path}\`** — ${r.file}:${r.line}${mw}`)
+      lines.push('')
+      if (r.queries.length === 0) {
+        lines.push('- _Sin queries directas._')
+      } else {
+        for (const q of r.queries) {
+          if (q.dynamic) {
+            lines.push(`- L${q.line} _dynamic SQL (\`${q.client}.query(variable)\`)_`)
+            continue
+          }
+          const orgTables = q.tables.filter(t => schema[t]?.hasOrgId)
+          const flag = orgTables.length > 0
+            ? (q.filtersByOrgId ? '[OK] ' : '[!!] ')
+            : '     '
+          const tables = q.tables.length ? ` → \`${q.tables.join(', ')}\`` : ''
+          lines.push(`- ${flag}L${q.line} ${q.op}${tables}`)
+        }
+      }
+      lines.push('')
+    }
+  }
+
+  if (helpers.length > 0) {
+    lines.push('## Helpers / factories con queries')
+    lines.push('')
+    for (const h of helpers) {
+      lines.push(`**\`${h.name}\`** — ${h.file}:${h.line}`)
+      lines.push('')
+      for (const q of h.queries) {
+        if (q.dynamic) {
+          lines.push(`- L${q.line} _dynamic SQL_`)
+          continue
+        }
+        const tables = q.tables.length ? ` → \`${q.tables.join(', ')}\`` : ''
+        lines.push(`- L${q.line} ${q.op}${tables}${q.filtersByOrgId ? ' (filtra org)' : ''}`)
+      }
+      lines.push('')
+    }
+  }
+
+  // Tables -> endpoints
+  lines.push('## Tablas → Endpoints')
+  lines.push('')
+  for (const name of Object.keys(tableIndex).sort()) {
+    const t = tableIndex[name]
+    const tag = t.defined ? '' : ' _(externa — better-auth u otra fuente)_'
+    lines.push(`### \`${name}\`${tag}`)
+    lines.push('')
+    if (t.schema) {
+      const colSummary = t.schema.columns.map(c => `\`${c.name}\` ${c.type}`).join(', ')
+      lines.push(`- **Columnas:** ${colSummary}`)
+      if (t.schema.fks.length) {
+        lines.push(`- **FK:** ${t.schema.fks.map(f => `\`${f.column}\` → \`${f.refTable}.${f.refColumn}\``).join(', ')}`)
+      }
+      lines.push(`- **Multi-tenant:** ${t.schema.hasOrgId ? 'si (organization_id)' : 'no'}`)
+    }
+    if (t.readers.length > 0) {
+      lines.push(`- **Lectores (${t.readers.length}):**`)
+      for (const r of t.readers) lines.push(`    - ${formatRef(r)}`)
+    }
+    if (t.writers.length > 0) {
+      lines.push(`- **Escritores (${t.writers.length}):**`)
+      for (const w of t.writers) lines.push(`    - ${formatRef(w)}`)
+    }
+    if (t.readers.length === 0 && t.writers.length === 0) {
+      lines.push('- _Sin queries detectadas._')
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n') + '\n'
+}
+
+function formatRef(ref) {
+  const guard = ref.filtersByOrgId ? '' : ' [sin filtro org]'
+  if (ref.kind === 'route') {
+    return `\`${ref.method} ${ref.path}\` (${ref.file}:${ref.line}, ${ref.op})${guard}`
+  }
+  return `helper \`${ref.helper}\` (${ref.file}:${ref.line}, ${ref.op})${guard}`
+}
+
+// ---------- Main ----------
+function main() {
+  const schemaPath = path.join(ROOT, 'db', 'init.sql')
+  const schema = parseSchema(readFile(schemaPath))
+
+  const serverFiles = [
+    path.join(ROOT, 'server', 'index.js'),
+    path.join(ROOT, 'server', 'auth.js'),
+  ]
+  const libDir = path.join(ROOT, 'server', 'lib')
+  if (fs.existsSync(libDir)) {
+    for (const f of fs.readdirSync(libDir).sort()) {
+      if (f.endsWith('.js') && !f.endsWith('.test.js')) {
+        serverFiles.push(path.join(libDir, f))
+      }
+    }
+  }
+
+  const routes = []
+  const helpers = []
+  for (const file of serverFiles) {
+    const rel = path.relative(ROOT, file)
+    const src = readFile(file)
+    const masked = maskSource(src)
+    const { routes: rs, bodyRanges } = parseRoutes(src, masked, rel)
+    routes.push(...rs)
+    helpers.push(...parseHelpers(src, masked, rel, bodyRanges))
+  }
+
+  // Pasada extra: buscar CREATE TABLE en las SQL extraidas (tablas creadas en runtime via migrate())
+  const allQueries = [
+    ...routes.flatMap(r => r.queries.map(q => ({ ...q, source: r.file }))),
+    ...helpers.flatMap(h => h.queries.map(q => ({ ...q, source: h.file }))),
+  ]
+  for (const q of allQueries) {
+    if (!q.sql || !/CREATE TABLE/i.test(q.sql)) continue
+    parseSchema(q.sql, schema, `${q.source}:${q.line}`)
+  }
+
+  const tableIndex = buildTableIndex(routes, helpers, schema)
+  const graph = {
+    generatedAt: new Date().toISOString(),
+    sources: serverFiles.map(f => path.relative(ROOT, f)).concat([path.relative(ROOT, schemaPath)]),
+    schema,
+    routes,
+    helpers,
+    tableIndex,
+  }
+
+  const jsonOut = path.join(ROOT, '.claude', 'code-graph.json')
+  const mdOut = path.join(ROOT, 'docs', 'CODE_GRAPH.md')
+  writeFile(jsonOut, JSON.stringify(graph, null, 2) + '\n')
+  writeFile(mdOut, renderMarkdown(graph))
+
+  const totalQueries = routes.reduce((a, r) => a + r.queries.length, 0)
+  console.log(`OK ${routes.length} rutas, ${totalQueries} queries, ${helpers.length} helpers con queries, ${Object.keys(tableIndex).length} tablas`)
+  console.log(`OK ${path.relative(ROOT, jsonOut)}`)
+  console.log(`OK ${path.relative(ROOT, mdOut)}`)
+}
+
+main()


### PR DESCRIPTION
Agrega `scripts/codegraph.js`, parser custom sin dependencias que escanea
`server/index.js`, `server/auth.js` y `server/lib/*.js` ademas de
`db/init.sql`, y emite:
- `.claude/code-graph.json` (estructurado, para Claude)
- `docs/CODE_GRAPH.md` (legible, con warnings multi-tenant)

El grafo cubre las 50 rutas del API, las 118 queries SQL detectadas y los
helpers/factories con queries (createRequireHouse, migrate,
sendPushToHouse, etc.), atribuyendo cada query al ambito mas chico que la
contiene para evitar doble conteo. Tambien parsea CREATE TABLE en
runtime (push_subscriptions creado por migrate()) y filtra schemas del
sistema (information_schema).

Resumen tras la primera corrida:
- 50 rutas, 78 queries estaticas + 6 dinamicas + 34 en helpers
- 59 queries filtran por organization_id (resto son lecturas globales,
  super_admin o filtros indirectos)
- 14 tablas referenciadas (10 propias + 4 de better-auth)
- 2 hallazgos en la seccion de warnings multi-tenant (revisar)

Uso: `npm run codegraph` despues de cambios en `server/` o `db/init.sql`.