### PR TITLE
feat: rol externo con marca de llegada y fecha heredada por las tareas

### DIFF
--- a/.claude/code-graph.json
+++ b/.claude/code-graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-27T23:26:31.706Z",
+  "generatedAt": "2026-06-11T00:15:06.321Z",
   "sources": [
     "server/index.js",
     "server/auth.js",
@@ -251,6 +251,37 @@
           "type": "TEXT"
         },
         {
+          "name": "member_type",
+          "type": "TEXT"
+        },
+        {
+          "name": "created_at",
+          "type": "TIMESTAMPTZ"
+        }
+      ],
+      "fks": [],
+      "hasOrgId": true,
+      "source": "db/init.sql"
+    },
+    "visits": {
+      "columns": [
+        {
+          "name": "id",
+          "type": "UUID"
+        },
+        {
+          "name": "organization_id",
+          "type": "TEXT"
+        },
+        {
+          "name": "user_id",
+          "type": "TEXT"
+        },
+        {
+          "name": "visited_on",
+          "type": "DATE"
+        },
+        {
           "name": "created_at",
           "type": "TIMESTAMPTZ"
         }
@@ -383,7 +414,7 @@
       ],
       "fks": [],
       "hasOrgId": true,
-      "source": "server/index.js:1450"
+      "source": "server/index.js:1562"
     }
   },
   "routes": [
@@ -523,7 +554,7 @@
           "line": 160,
           "client": "pool",
           "dynamic": false,
-          "sql": "SELECT m.\"userId\", m.role, m.\"createdAt\",\n             u.name, u.email,\n             COALESCE(p.avatar, '🧑') as avatar,\n             COALESCE(p.color, '#6a9960') as color\n      FROM \"member\" m\n      JOIN \"user\" u ON m.\"userId\" = u.id\n      LEFT JOIN house_member_profiles p ON p.user_id = m.\"userId\" AND p.organization_id = m.\"organizationId\"\n      WHERE m.\"organizationId\" = $1\n      ORDER BY m.\"createdAt\"",
+          "sql": "SELECT m.\"userId\", m.role, m.\"createdAt\",\n             u.name, u.email,\n             COALESCE(p.avatar, '🧑') as avatar,\n             COALESCE(p.color, '#6a9960') as color,\n             COALESCE(p.member_type, 'regular') as member_type\n      FROM \"member\" m\n      JOIN \"user\" u ON m.\"userId\" = u.id\n      LEFT JOIN house_member_profiles p ON p.user_id = m.\"userId\" AND p.organization_id = m.\"organizationId\"\n      WHERE m.\"organizationId\" = $1\n      ORDER BY m.\"createdAt\"",
           "op": "SELECT",
           "tables": [
             "member",
@@ -536,16 +567,51 @@
     },
     {
       "file": "server/index.js",
+      "method": "PATCH",
+      "path": "/api/houses/members/:userId/type",
+      "line": 181,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse",
+        "requireRole('owner', 'admin')"
+      ],
+      "queries": [
+        {
+          "line": 188,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT role FROM \"member\" WHERE \"userId\" = $1 AND \"organizationId\" = $2",
+          "op": "SELECT",
+          "tables": [
+            "member"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 195,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "INSERT INTO house_member_profiles (user_id, organization_id, member_type)\n      VALUES ($1, $2, $3)\n      ON CONFLICT (user_id, organization_id)\n      DO UPDATE SET member_type = EXCLUDED.member_type",
+          "op": "INSERT",
+          "tables": [
+            "house_member_profiles"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
       "method": "GET",
       "path": "/api/houses/profile",
-      "line": 180,
+      "line": 210,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 182,
+          "line": 212,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT * FROM house_member_profiles WHERE user_id = $1 AND organization_id = $2",
@@ -561,14 +627,14 @@
       "file": "server/index.js",
       "method": "PUT",
       "path": "/api/houses/profile",
-      "line": 198,
+      "line": 229,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 204,
+          "line": 235,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT avatar, color, home_screen FROM house_member_profiles WHERE user_id = $1 AND organization_id = $2",
@@ -579,7 +645,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 212,
+          "line": 243,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO house_member_profiles (user_id, organization_id, avatar, color, home_screen)\n      VALUES ($1, $2, $3, $4, $5)\n      ON CONFLICT (user_id, organization_id)\n      DO UPDATE SET avatar = EXCLUDED.avatar, color = EXCLUDED.color, home_screen = EXCLUDED.home_screen\n      RETURNING *",
@@ -595,7 +661,7 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/invitations",
-      "line": 226,
+      "line": 257,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -603,7 +669,7 @@
       ],
       "queries": [
         {
-          "line": 228,
+          "line": 259,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT i.id, i.email, i.role, i.status, i.\"expiresAt\", i.\"inviterId\",\n             u.name as inviter_name, u.email as inviter_email\n      FROM \"invitation\" i\n      LEFT JOIN \"user\" u ON u.id = i.\"inviterId\"\n      WHERE i.\"organizationId\" = $1 AND i.status = 'pending'\n      ORDER BY i.\"expiresAt\" DESC",
@@ -620,7 +686,7 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/invitations/:id",
-      "line": 243,
+      "line": 274,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -628,7 +694,7 @@
       ],
       "queries": [
         {
-          "line": 245,
+          "line": 276,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM \"invitation\" WHERE id = $1 AND \"organizationId\" = $2 AND status = 'pending'",
@@ -644,7 +710,7 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/invitations/:id/renew",
-      "line": 259,
+      "line": 290,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -652,7 +718,7 @@
       ],
       "queries": [
         {
-          "line": 261,
+          "line": 292,
           "client": "pool",
           "dynamic": false,
           "sql": "UPDATE \"invitation\"\n       SET \"expiresAt\" = NOW() + INTERVAL '7 days'\n       WHERE id = $1 AND \"organizationId\" = $2 AND status = 'pending'\n       RETURNING id, email, role, status, \"expiresAt\"",
@@ -668,13 +734,13 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/houses/:id",
-      "line": 278,
+      "line": 309,
       "middlewares": [
         "requireAuth"
       ],
       "queries": [
         {
-          "line": 285,
+          "line": 316,
           "client": "client",
           "dynamic": false,
           "sql": "SELECT role FROM \"member\" WHERE \"userId\" = $1 AND \"organizationId\" = $2",
@@ -685,7 +751,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 296,
+          "line": 327,
           "client": "client",
           "dynamic": false,
           "sql": "BEGIN",
@@ -694,7 +760,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 298,
+          "line": 329,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM tasks WHERE organization_id = $1",
@@ -705,7 +771,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 299,
+          "line": 330,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM products WHERE organization_id = $1",
@@ -716,7 +782,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 300,
+          "line": 331,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM shopping_items WHERE organization_id = $1",
@@ -727,7 +793,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 301,
+          "line": 332,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM shopping_categories WHERE organization_id = $1",
@@ -738,7 +804,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 302,
+          "line": 333,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM house_member_profiles WHERE organization_id = $1",
@@ -749,7 +815,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 303,
+          "line": 334,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM push_subscriptions WHERE organization_id = $1",
@@ -760,7 +826,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 304,
+          "line": 335,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM plant_watering_history WHERE plant_id IN (SELECT id FROM plants WHERE organization_id = $1)",
@@ -772,7 +838,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 308,
+          "line": 339,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM plants WHERE organization_id = $1",
@@ -783,7 +849,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 310,
+          "line": 341,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM \"invitation\" WHERE \"organizationId\" = $1",
@@ -794,7 +860,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 311,
+          "line": 342,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM \"member\" WHERE \"organizationId\" = $1",
@@ -805,7 +871,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 312,
+          "line": 343,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM \"organization\" WHERE id = $1",
@@ -816,7 +882,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 313,
+          "line": 344,
           "client": "client",
           "dynamic": false,
           "sql": "COMMIT",
@@ -825,7 +891,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 317,
+          "line": 348,
           "client": "client",
           "dynamic": false,
           "sql": "ROLLBACK",
@@ -839,7 +905,7 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/houses/seed",
-      "line": 325,
+      "line": 356,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -847,7 +913,7 @@
       ],
       "queries": [
         {
-          "line": 332,
+          "line": 363,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT COUNT(*) as c FROM tasks WHERE organization_id = $1",
@@ -858,7 +924,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 368,
+          "line": 399,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO tasks (name, description, frequency_type, frequency_value, is_active, organization_id) VALUES ${values}",
@@ -869,7 +935,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 404,
+          "line": 435,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO tasks (name, description, frequency_type, frequency_value, is_active, organization_id) VALUES ${values}",
@@ -880,7 +946,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 460,
+          "line": 491,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO products (name, category, reminder_frequency_days, is_out_of_stock, organization_id) VALUES ${pValues}",
@@ -896,11 +962,11 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/health",
-      "line": 473,
+      "line": 504,
       "middlewares": [],
       "queries": [
         {
-          "line": 475,
+          "line": 506,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT 1",
@@ -914,7 +980,7 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/uploads",
-      "line": 484,
+      "line": 515,
       "middlewares": [
         "requireAuth",
         "upload.single('image')"
@@ -925,7 +991,7 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/uploads/:filename",
-      "line": 489,
+      "line": 520,
       "middlewares": [
         "requireAuth"
       ],
@@ -935,14 +1001,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/tasks/pending",
-      "line": 501,
+      "line": 532,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 503,
+          "line": 534,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT t.*, c.last_completed_at\n      FROM tasks t\n      LEFT JOIN (\n        SELECT task_id, MAX(completed_at) AS last_completed_at\n        FROM completions\n        GROUP BY task_id\n      ) c ON t.id = c.task_id\n      WHERE t.is_active = true\n        AND t.organization_id = $1\n        AND (\n          c.last_completed_at IS NULL\n          OR (t.frequency_type <> 'once' AND NOW() >= c.last_completed_at + (t.frequency_value * INTERVAL '1 day'))\n          OR (t.last_reset_at IS NOT NULL AND t.last_reset_at > c.last_completed_at)\n        )\n      ORDER BY t.name",
@@ -959,14 +1025,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/tasks",
-      "line": 527,
+      "line": 558,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 533,
+          "line": 564,
           "client": "pool",
           "dynamic": true,
           "sql": null,
@@ -980,7 +1046,7 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/tasks",
-      "line": 541,
+      "line": 572,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -988,7 +1054,7 @@
       ],
       "queries": [
         {
-          "line": 544,
+          "line": 575,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO tasks (name, description, frequency_type, frequency_value, is_active, product_name, product_image, organization_id)\n       VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *",
@@ -1004,7 +1070,7 @@
       "file": "server/index.js",
       "method": "PATCH",
       "path": "/api/tasks/:id",
-      "line": 556,
+      "line": 587,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -1012,7 +1078,7 @@
       ],
       "queries": [
         {
-          "line": 566,
+          "line": 597,
           "client": "pool",
           "dynamic": true,
           "sql": null,
@@ -1026,7 +1092,7 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/tasks/:id",
-      "line": 575,
+      "line": 606,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -1034,7 +1100,7 @@
       ],
       "queries": [
         {
-          "line": 578,
+          "line": 609,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT product_image FROM tasks WHERE id = $1 AND organization_id = $2",
@@ -1045,7 +1111,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 585,
+          "line": 616,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM completions WHERE task_id = $1",
@@ -1056,7 +1122,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 586,
+          "line": 617,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM tasks WHERE id = $1 AND organization_id = $2",
@@ -1072,14 +1138,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/completions",
-      "line": 596,
+      "line": 627,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 598,
+          "line": 629,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT c.task_id, c.completed_at, c.completed_by, c.user_id\n      FROM completions c\n      JOIN tasks t ON c.task_id = t.id\n      WHERE t.organization_id = $1\n      ORDER BY c.completed_at DESC",
@@ -1096,14 +1162,14 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/completions",
-      "line": 612,
+      "line": 643,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 616,
+          "line": 647,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT id, name, frequency_type FROM tasks WHERE id = $1 AND organization_id = $2",
@@ -1114,7 +1180,18 @@
           "filtersByOrgId": true
         },
         {
-          "line": 621,
+          "line": 656,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT to_char(visited_on, 'YYYY-MM-DD') AS d\n        FROM visits\n        WHERE organization_id = $1 AND user_id = $2\n        ORDER BY created_at DESC\n        LIMIT 1",
+          "op": "SELECT",
+          "tables": [
+            "visits"
+          ],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 673,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO completions (task_id, completed_at, completed_by, user_id) VALUES ($1, $2, $3, $4) RETURNING *",
@@ -1125,7 +1202,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 628,
+          "line": 680,
           "client": "pool",
           "dynamic": false,
           "sql": "UPDATE tasks SET is_active = false WHERE id = $1 AND organization_id = $2",
@@ -1139,9 +1216,64 @@
     },
     {
       "file": "server/index.js",
+      "method": "GET",
+      "path": "/api/visits/active",
+      "line": 706,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 708,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT id, to_char(visited_on, 'YYYY-MM-DD') AS visited_on, created_at\n      FROM visits\n      WHERE organization_id = $1 AND user_id = $2\n      ORDER BY created_at DESC\n      LIMIT 1",
+          "op": "SELECT",
+          "tables": [
+            "visits"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
+      "method": "POST",
+      "path": "/api/visits",
+      "line": 722,
+      "middlewares": [
+        "requireAuth",
+        "requireHouse"
+      ],
+      "queries": [
+        {
+          "line": 731,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "SELECT ($1::date > CURRENT_DATE) AS future",
+          "op": "SELECT",
+          "tables": [],
+          "filtersByOrgId": false
+        },
+        {
+          "line": 735,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "INSERT INTO visits (organization_id, user_id, visited_on)\n      VALUES ($1, $2, $3)\n      RETURNING id, to_char(visited_on, 'YYYY-MM-DD') AS visited_on, created_at",
+          "op": "INSERT",
+          "tables": [
+            "visits"
+          ],
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    {
+      "file": "server/index.js",
       "method": "POST",
       "path": "/api/tasks/:id/reset",
-      "line": 651,
+      "line": 748,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -1149,7 +1281,7 @@
       ],
       "queries": [
         {
-          "line": 654,
+          "line": 751,
           "client": "pool",
           "dynamic": false,
           "sql": "UPDATE tasks SET last_reset_at = NOW() WHERE id = $1 AND organization_id = $2 RETURNING *",
@@ -1165,14 +1297,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/completions/:taskId/history",
-      "line": 666,
+      "line": 763,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 669,
+          "line": 766,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT c.* FROM completions c\n      JOIN tasks t ON c.task_id = t.id\n      WHERE c.task_id = $1 AND t.organization_id = $2\n      ORDER BY c.completed_at DESC LIMIT $3",
@@ -1189,14 +1321,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/products",
-      "line": 684,
+      "line": 781,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 700,
+          "line": 797,
           "client": "pool",
           "dynamic": true,
           "sql": null,
@@ -1210,14 +1342,14 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/products",
-      "line": 708,
+      "line": 805,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 712,
+          "line": 809,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO products (name, category, reminder_frequency_days, is_out_of_stock, units, organization_id)\n       VALUES ($1, $2, $3, $4, $5, $6) RETURNING *",
@@ -1233,14 +1365,14 @@
       "file": "server/index.js",
       "method": "PATCH",
       "path": "/api/products/:id",
-      "line": 724,
+      "line": 821,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 740,
+          "line": 837,
           "client": "pool",
           "dynamic": true,
           "sql": null,
@@ -1254,14 +1386,14 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/products/:id/purchase",
-      "line": 749,
+      "line": 846,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 752,
+          "line": 849,
           "client": "pool",
           "dynamic": false,
           "sql": "UPDATE products\n       SET last_purchased_at = NOW(), is_out_of_stock = false, last_out_of_stock_at = NULL\n       WHERE id = $1 AND organization_id = $2 RETURNING *",
@@ -1277,14 +1409,14 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/products/:id",
-      "line": 766,
+      "line": 863,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 769,
+          "line": 866,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM products WHERE id = $1 AND organization_id = $2",
@@ -1300,14 +1432,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/shopping-categories",
-      "line": 779,
+      "line": 876,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 781,
+          "line": 878,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT * FROM shopping_categories WHERE organization_id = $1 ORDER BY sort_order, name",
@@ -1323,7 +1455,7 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/shopping-categories",
-      "line": 792,
+      "line": 889,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -1331,7 +1463,7 @@
       ],
       "queries": [
         {
-          "line": 797,
+          "line": 894,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT COALESCE(MAX(sort_order), -1) + 1 as next_order FROM shopping_categories WHERE organization_id = $1",
@@ -1342,7 +1474,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 801,
+          "line": 898,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO shopping_categories (name, emoji, sort_order, organization_id) VALUES ($1, $2, $3, $4) RETURNING *",
@@ -1358,7 +1490,7 @@
       "file": "server/index.js",
       "method": "PATCH",
       "path": "/api/shopping-categories/:id",
-      "line": 812,
+      "line": 909,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -1366,7 +1498,7 @@
       ],
       "queries": [
         {
-          "line": 822,
+          "line": 919,
           "client": "pool",
           "dynamic": true,
           "sql": null,
@@ -1380,7 +1512,7 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/shopping-categories/:id",
-      "line": 831,
+      "line": 928,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -1388,7 +1520,7 @@
       ],
       "queries": [
         {
-          "line": 834,
+          "line": 931,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM shopping_categories WHERE id = $1 AND organization_id = $2",
@@ -1404,14 +1536,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/shopping-items",
-      "line": 844,
+      "line": 941,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 847,
+          "line": 944,
           "client": "pool",
           "dynamic": false,
           "sql": "UPDATE shopping_items\n       SET archived_at = NOW()\n       WHERE organization_id = $1\n         AND is_purchased = true\n         AND archived_at IS NULL\n         AND purchased_at IS NOT NULL\n         AND purchased_at < NOW() - ($2 || ' days')::INTERVAL",
@@ -1422,7 +1554,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 858,
+          "line": 955,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT si.*, sc.name as category_name, sc.emoji as category_emoji\n      FROM shopping_items si\n      LEFT JOIN shopping_categories sc ON si.category_id = sc.id\n      WHERE si.organization_id = $1 AND si.archived_at IS NULL\n      ORDER BY si.is_purchased, sc.sort_order NULLS LAST, si.created_at DESC",
@@ -1439,14 +1571,14 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/shopping-items",
-      "line": 872,
+      "line": 969,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 876,
+          "line": 973,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO shopping_items (name, note, added_by, category_id, organization_id) VALUES ($1, $2, $3, $4, $5) RETURNING *",
@@ -1462,14 +1594,14 @@
       "file": "server/index.js",
       "method": "PATCH",
       "path": "/api/shopping-items/:id",
-      "line": 887,
+      "line": 984,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 909,
+          "line": 1006,
           "client": "pool",
           "dynamic": true,
           "sql": null,
@@ -1483,14 +1615,14 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/shopping-items/clear-purchased",
-      "line": 919,
+      "line": 1016,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 922,
+          "line": 1019,
           "client": "pool",
           "dynamic": false,
           "sql": "UPDATE shopping_items\n       SET purchased_at = COALESCE(purchased_at, NOW()),\n           archived_at = NOW()\n       WHERE is_purchased = true\n         AND archived_at IS NULL\n         AND organization_id = $1",
@@ -1506,14 +1638,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/shopping-items/history",
-      "line": 939,
+      "line": 1036,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 942,
+          "line": 1039,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT si.*, sc.name as category_name, sc.emoji as category_emoji\n      FROM shopping_items si\n      LEFT JOIN shopping_categories sc ON si.category_id = sc.id\n      WHERE si.organization_id = $1 AND si.archived_at IS NOT NULL\n      ORDER BY si.archived_at DESC, si.purchased_at DESC NULLS LAST\n      LIMIT $2",
@@ -1530,14 +1662,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/shopping-items/recommendations",
-      "line": 958,
+      "line": 1055,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 960,
+          "line": 1057,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT si.id, si.name, si.category_id, si.purchased_at,\n             sc.name as category_name, sc.emoji as category_emoji\n      FROM shopping_items si\n      LEFT JOIN shopping_categories sc ON si.category_id = sc.id\n      WHERE si.organization_id = $1\n        AND si.archived_at IS NOT NULL\n        AND si.purchased_at IS NOT NULL\n      ORDER BY si.purchased_at DESC",
@@ -1549,7 +1681,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 971,
+          "line": 1068,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT name FROM shopping_items\n       WHERE organization_id = $1 AND archived_at IS NULL",
@@ -1565,14 +1697,14 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/shopping-items/:id",
-      "line": 985,
+      "line": 1082,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 988,
+          "line": 1085,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM shopping_items WHERE id = $1 AND organization_id = $2",
@@ -1588,14 +1720,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/plants",
-      "line": 998,
+      "line": 1095,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1000,
+          "line": 1097,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT * FROM plants WHERE organization_id = $1 ORDER BY name",
@@ -1611,14 +1743,14 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/plants",
-      "line": 1011,
+      "line": 1108,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1016,
+          "line": 1113,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO plants (name, notes, watering_frequency_days, organization_id)\n       VALUES ($1, $2, $3, $4) RETURNING *",
@@ -1634,14 +1766,14 @@
       "file": "server/index.js",
       "method": "PATCH",
       "path": "/api/plants/:id",
-      "line": 1028,
+      "line": 1125,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1035,
+          "line": 1132,
           "client": "pool",
           "dynamic": false,
           "sql": "UPDATE plants SET name = $3, notes = $4, watering_frequency_days = $5\n       WHERE id = $1 AND organization_id = $2 RETURNING *",
@@ -1657,14 +1789,14 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/plants/:id",
-      "line": 1048,
+      "line": 1145,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1051,
+          "line": 1148,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM plants WHERE id = $1 AND organization_id = $2",
@@ -1680,14 +1812,14 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/plants/:id/water",
-      "line": 1063,
+      "line": 1160,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1067,
+          "line": 1164,
           "client": "client",
           "dynamic": false,
           "sql": "SELECT id, name FROM plants WHERE id = $1 AND organization_id = $2",
@@ -1698,7 +1830,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1073,
+          "line": 1170,
           "client": "client",
           "dynamic": false,
           "sql": "BEGIN",
@@ -1707,7 +1839,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1074,
+          "line": 1171,
           "client": "client",
           "dynamic": false,
           "sql": "INSERT INTO plant_watering_history (plant_id, watered_at, watered_by, user_id) VALUES ($1, NOW(), $2, $3)",
@@ -1718,7 +1850,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1078,
+          "line": 1175,
           "client": "client",
           "dynamic": false,
           "sql": "UPDATE plants SET last_watered_at = NOW() WHERE id = $1 AND organization_id = $2 RETURNING *",
@@ -1729,7 +1861,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1082,
+          "line": 1179,
           "client": "client",
           "dynamic": false,
           "sql": "COMMIT",
@@ -1738,7 +1870,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1092,
+          "line": 1189,
           "client": "client",
           "dynamic": false,
           "sql": "ROLLBACK",
@@ -1752,14 +1884,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/plants/:id/history",
-      "line": 1100,
+      "line": 1197,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1103,
+          "line": 1200,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT h.* FROM plant_watering_history h\n      JOIN plants p ON h.plant_id = p.id\n      WHERE h.plant_id = $1 AND p.organization_id = $2\n      ORDER BY h.watered_at DESC LIMIT $3",
@@ -1776,14 +1908,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/stats/participation",
-      "line": 1118,
+      "line": 1215,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1129,
+          "line": 1226,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT\n        c.user_id,\n        COALESCE(c.completed_by, 'Desconocido') as name,\n        COALESCE(p.avatar, '🧑') as avatar,\n        COALESCE(p.color, '#6a9960') as color,\n        COUNT(*) as completions\n      FROM completions c\n      JOIN tasks t ON c.task_id = t.id\n      LEFT JOIN house_member_profiles p ON p.user_id = c.user_id AND p.organization_id = t.organization_id\n      WHERE t.organization_id = $1 ${dateFilter}\n      GROUP BY c.user_id, c.completed_by, p.avatar, p.color\n      ORDER BY completions DESC",
@@ -1796,7 +1928,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1149,
+          "line": 1246,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT\n        DATE(c.completed_at) as date,\n        COUNT(*) as count\n      FROM completions c\n      JOIN tasks t ON c.task_id = t.id\n      WHERE t.organization_id = $1\n        AND c.completed_at >= NOW() - INTERVAL '${chartDays} days'\n      GROUP BY DATE(c.completed_at)\n      ORDER BY date",
@@ -1808,7 +1940,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1162,
+          "line": 1259,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT\n        t.name,\n        COUNT(*) as completions\n      FROM completions c\n      JOIN tasks t ON c.task_id = t.id\n      WHERE t.organization_id = $1 ${dateFilter}\n      GROUP BY t.name\n      ORDER BY completions DESC\n      LIMIT 5",
@@ -1825,7 +1957,7 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/push/vapid-key",
-      "line": 1204,
+      "line": 1301,
       "middlewares": [],
       "queries": []
     },
@@ -1833,14 +1965,14 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/push/subscribe",
-      "line": 1211,
+      "line": 1308,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1218,
+          "line": 1315,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO push_subscriptions (user_id, organization_id, endpoint, keys_p256dh, keys_auth)\n      VALUES ($1, $2, $3, $4, $5)\n      ON CONFLICT (endpoint) DO UPDATE SET\n        user_id = EXCLUDED.user_id,\n        organization_id = EXCLUDED.organization_id,\n        keys_p256dh = EXCLUDED.keys_p256dh,\n        keys_auth = EXCLUDED.keys_auth,\n        updated_at = NOW()",
@@ -1856,13 +1988,13 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/push/subscribe",
-      "line": 1236,
+      "line": 1333,
       "middlewares": [
         "requireAuth"
       ],
       "queries": [
         {
-          "line": 1240,
+          "line": 1337,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM push_subscriptions WHERE endpoint = $1 AND user_id = $2",
@@ -1878,14 +2010,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/push/status",
-      "line": 1248,
+      "line": 1345,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1250,
+          "line": 1347,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT id FROM push_subscriptions WHERE user_id = $1 AND organization_id = $2 LIMIT 1",
@@ -1902,10 +2034,10 @@
     {
       "name": "sendPushToHouse",
       "file": "server/index.js",
-      "line": 1261,
+      "line": 1358,
       "queries": [
         {
-          "line": 1265,
+          "line": 1362,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT endpoint, keys_p256dh, keys_auth FROM push_subscriptions WHERE organization_id = $1",
@@ -1916,7 +2048,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1279,
+          "line": 1376,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM push_subscriptions WHERE endpoint = $1",
@@ -1931,10 +2063,10 @@
     {
       "name": "migrate",
       "file": "server/index.js",
-      "line": 1291,
+      "line": 1388,
       "queries": [
         {
-          "line": 1294,
+          "line": 1391,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS tasks (\n        id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        name        TEXT NOT NULL,\n        description TEXT,\n        frequency_type  TEXT NOT NULL CHECK (frequency_type IN ('daily', 'weekly', 'biweekly', 'monthly')),\n        frequency_value INTEGER NOT NULL DEFAULT 1,\n        is_active   BOOLEAN NOT NULL DEFAULT true,\n        product_name  TEXT,\n        product_image TEXT,\n        organization_id TEXT,\n        created_at  TIMESTAMPTZ DEFAULT NOW()\n      )",
@@ -1943,7 +2075,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1309,
+          "line": 1406,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS completions (\n        id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        task_id     UUID NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,\n        completed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n        completed_by TEXT,\n        user_id TEXT\n      )",
@@ -1952,7 +2084,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1318,
+          "line": 1415,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_completions_task_id ON completions(task_id)",
@@ -1961,7 +2093,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1319,
+          "line": 1416,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_completions_completed_at ON completions(completed_at DESC)",
@@ -1970,7 +2102,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1321,
+          "line": 1418,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS products (\n        id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        name            TEXT NOT NULL,\n        category        TEXT NOT NULL DEFAULT 'general',\n        is_out_of_stock BOOLEAN NOT NULL DEFAULT false,\n        reminder_frequency_days INTEGER NOT NULL DEFAULT 30,\n        last_purchased_at TIMESTAMPTZ,\n        organization_id TEXT,\n        created_at      TIMESTAMPTZ DEFAULT NOW()\n      )",
@@ -1979,7 +2111,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1333,
+          "line": 1430,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_products_category ON products(category)",
@@ -1988,7 +2120,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1334,
+          "line": 1431,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_products_out_of_stock ON products(is_out_of_stock)",
@@ -1997,7 +2129,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1336,
+          "line": 1433,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS shopping_categories (\n        id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        name            TEXT NOT NULL,\n        emoji           TEXT NOT NULL DEFAULT '📦',\n        sort_order      INTEGER NOT NULL DEFAULT 0,\n        organization_id TEXT NOT NULL,\n        created_at      TIMESTAMPTZ DEFAULT NOW()\n      )",
@@ -2006,7 +2138,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1346,
+          "line": 1443,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_categories_org ON shopping_categories(organization_id)",
@@ -2015,7 +2147,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1348,
+          "line": 1445,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS shopping_items (\n        id           UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        name         TEXT NOT NULL,\n        note         TEXT,\n        added_by     TEXT,\n        is_purchased BOOLEAN NOT NULL DEFAULT false,\n        category_id  UUID REFERENCES shopping_categories(id) ON DELETE SET NULL,\n        organization_id TEXT,\n        created_at   TIMESTAMPTZ DEFAULT NOW()\n      )",
@@ -2024,7 +2156,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1360,
+          "line": 1457,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_purchased ON shopping_items(is_purchased)",
@@ -2033,7 +2165,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1361,
+          "line": 1458,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_category ON shopping_items(category_id)",
@@ -2042,7 +2174,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1383,
+          "line": 1480,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_tasks_org ON tasks(organization_id)",
@@ -2051,7 +2183,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1384,
+          "line": 1481,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_products_org ON products(organization_id)",
@@ -2060,7 +2192,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1385,
+          "line": 1482,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_org ON shopping_items(organization_id)",
@@ -2069,7 +2201,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1389,
+          "line": 1486,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_category ON shopping_items(category_id)",
@@ -2078,7 +2210,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1397,
+          "line": 1497,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_archived ON shopping_items(archived_at)",
@@ -2087,7 +2219,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1398,
+          "line": 1498,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_purchased_at ON shopping_items(purchased_at DESC)",
@@ -2096,7 +2228,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1401,
+          "line": 1501,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS house_member_profiles (\n        id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        user_id         TEXT NOT NULL,\n        organization_id TEXT NOT NULL,\n        avatar          TEXT NOT NULL DEFAULT '🧑',\n        color           TEXT NOT NULL DEFAULT '#6a9960',\n        home_screen     TEXT NOT NULL DEFAULT 'tasks',\n        created_at      TIMESTAMPTZ DEFAULT NOW(),\n        UNIQUE(user_id, organization_id)\n      )",
@@ -2105,7 +2237,25 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1415,
+          "line": 1515,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE TABLE IF NOT EXISTS visits (\n        id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        organization_id TEXT NOT NULL,\n        user_id         TEXT NOT NULL,\n        visited_on      DATE NOT NULL,\n        created_at      TIMESTAMPTZ DEFAULT NOW()\n      )",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1524,
+          "client": "pool",
+          "dynamic": false,
+          "sql": "CREATE INDEX IF NOT EXISTS idx_visits_org_user ON visits(organization_id, user_id, created_at DESC)",
+          "op": "CREATE",
+          "tables": [],
+          "filtersByOrgId": true
+        },
+        {
+          "line": 1527,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS super_admins (\n        id         UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        user_id    TEXT NOT NULL UNIQUE,\n        created_at TIMESTAMPTZ DEFAULT NOW()\n      )",
@@ -2114,7 +2264,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1424,
+          "line": 1536,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS plants (\n        id                       UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        name                     TEXT NOT NULL,\n        notes                    TEXT,\n        watering_frequency_days  INTEGER NOT NULL DEFAULT 7,\n        last_watered_at          TIMESTAMPTZ,\n        organization_id          TEXT NOT NULL,\n        created_at               TIMESTAMPTZ DEFAULT NOW()\n      )",
@@ -2123,7 +2273,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1435,
+          "line": 1547,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_plants_org ON plants(organization_id)",
@@ -2132,7 +2282,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1437,
+          "line": 1549,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS plant_watering_history (\n        id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        plant_id    UUID NOT NULL REFERENCES plants(id) ON DELETE CASCADE,\n        watered_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n        watered_by  TEXT,\n        user_id     TEXT\n      )",
@@ -2141,7 +2291,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1446,
+          "line": 1558,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_plant_watering_plant_id ON plant_watering_history(plant_id)",
@@ -2150,7 +2300,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1447,
+          "line": 1559,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_plant_watering_at ON plant_watering_history(watered_at DESC)",
@@ -2159,7 +2309,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1450,
+          "line": 1562,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS push_subscriptions (\n        id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        user_id         TEXT NOT NULL,\n        organization_id TEXT NOT NULL,\n        endpoint        TEXT NOT NULL UNIQUE,\n        keys_p256dh     TEXT NOT NULL,\n        keys_auth       TEXT NOT NULL,\n        created_at      TIMESTAMPTZ DEFAULT NOW(),\n        updated_at      TIMESTAMPTZ DEFAULT NOW()\n      )",
@@ -2168,7 +2318,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1462,
+          "line": 1574,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_push_subs_org ON push_subscriptions(organization_id)",
@@ -2177,7 +2327,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1463,
+          "line": 1575,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_push_subs_user ON push_subscriptions(user_id)",
@@ -2190,10 +2340,10 @@
     {
       "name": "addColumnIfMissing",
       "file": "server/index.js",
-      "line": 1471,
+      "line": 1583,
       "queries": [
         {
-          "line": 1472,
+          "line": 1584,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT column_name FROM information_schema.columns\n    WHERE table_name = $1 AND column_name = $2",
@@ -2202,7 +2352,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1477,
+          "line": 1589,
           "client": "pool",
           "dynamic": false,
           "sql": "ALTER TABLE ${table} ADD COLUMN ${column} ${type}",
@@ -2221,10 +2371,11 @@
           "line": 47,
           "client": "pool",
           "dynamic": false,
-          "sql": "SELECT * FROM \"member\" WHERE \"userId\" = $1 AND \"organizationId\" = $2",
+          "sql": "SELECT m.role, COALESCE(p.member_type, 'regular') AS member_type\n         FROM \"member\" m\n         LEFT JOIN house_member_profiles p\n           ON p.user_id = m.\"userId\" AND p.organization_id = m.\"organizationId\"\n         WHERE \"userId\" = $1 AND \"organizationId\" = $2",
           "op": "SELECT",
           "tables": [
-            "member"
+            "member",
+            "house_member_profiles"
           ],
           "filtersByOrgId": true
         }
@@ -2233,10 +2384,10 @@
     {
       "name": "requireSuperAdmin",
       "file": "server/lib/middleware.js",
-      "line": 66,
+      "line": 70,
       "queries": [
         {
-          "line": 68,
+          "line": 72,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT id FROM super_admins WHERE user_id = $1",
@@ -2327,7 +2478,7 @@
           "method": "POST",
           "path": "/api/houses/seed",
           "file": "server/index.js",
-          "line": 332,
+          "line": 363,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2336,7 +2487,7 @@
           "method": "GET",
           "path": "/api/tasks/pending",
           "file": "server/index.js",
-          "line": 503,
+          "line": 534,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2345,7 +2496,7 @@
           "method": "DELETE",
           "path": "/api/tasks/:id",
           "file": "server/index.js",
-          "line": 578,
+          "line": 609,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2354,7 +2505,7 @@
           "method": "GET",
           "path": "/api/completions",
           "file": "server/index.js",
-          "line": 598,
+          "line": 629,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2363,7 +2514,7 @@
           "method": "POST",
           "path": "/api/completions",
           "file": "server/index.js",
-          "line": 616,
+          "line": 647,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2372,7 +2523,7 @@
           "method": "GET",
           "path": "/api/completions/:taskId/history",
           "file": "server/index.js",
-          "line": 669,
+          "line": 766,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2381,7 +2532,7 @@
           "method": "GET",
           "path": "/api/stats/participation",
           "file": "server/index.js",
-          "line": 1129,
+          "line": 1226,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2390,7 +2541,7 @@
           "method": "GET",
           "path": "/api/stats/participation",
           "file": "server/index.js",
-          "line": 1149,
+          "line": 1246,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2399,7 +2550,7 @@
           "method": "GET",
           "path": "/api/stats/participation",
           "file": "server/index.js",
-          "line": 1162,
+          "line": 1259,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -2410,7 +2561,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 298,
+          "line": 329,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -2419,7 +2570,7 @@
           "method": "POST",
           "path": "/api/houses/seed",
           "file": "server/index.js",
-          "line": 368,
+          "line": 399,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -2428,7 +2579,7 @@
           "method": "POST",
           "path": "/api/houses/seed",
           "file": "server/index.js",
-          "line": 404,
+          "line": 435,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -2437,7 +2588,7 @@
           "method": "POST",
           "path": "/api/tasks",
           "file": "server/index.js",
-          "line": 544,
+          "line": 575,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -2446,7 +2597,7 @@
           "method": "DELETE",
           "path": "/api/tasks/:id",
           "file": "server/index.js",
-          "line": 586,
+          "line": 617,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -2455,7 +2606,7 @@
           "method": "POST",
           "path": "/api/completions",
           "file": "server/index.js",
-          "line": 628,
+          "line": 680,
           "op": "UPDATE",
           "filtersByOrgId": true
         },
@@ -2464,7 +2615,7 @@
           "method": "POST",
           "path": "/api/tasks/:id/reset",
           "file": "server/index.js",
-          "line": 654,
+          "line": 751,
           "op": "UPDATE",
           "filtersByOrgId": true
         }
@@ -2538,7 +2689,7 @@
           "method": "GET",
           "path": "/api/tasks/pending",
           "file": "server/index.js",
-          "line": 503,
+          "line": 534,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2547,7 +2698,7 @@
           "method": "GET",
           "path": "/api/completions",
           "file": "server/index.js",
-          "line": 598,
+          "line": 629,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2556,7 +2707,7 @@
           "method": "GET",
           "path": "/api/completions/:taskId/history",
           "file": "server/index.js",
-          "line": 669,
+          "line": 766,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2565,7 +2716,7 @@
           "method": "GET",
           "path": "/api/stats/participation",
           "file": "server/index.js",
-          "line": 1129,
+          "line": 1226,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2574,7 +2725,7 @@
           "method": "GET",
           "path": "/api/stats/participation",
           "file": "server/index.js",
-          "line": 1149,
+          "line": 1246,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2583,7 +2734,7 @@
           "method": "GET",
           "path": "/api/stats/participation",
           "file": "server/index.js",
-          "line": 1162,
+          "line": 1259,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -2594,7 +2745,7 @@
           "method": "DELETE",
           "path": "/api/tasks/:id",
           "file": "server/index.js",
-          "line": 585,
+          "line": 616,
           "op": "DELETE",
           "filtersByOrgId": false
         },
@@ -2603,7 +2754,7 @@
           "method": "POST",
           "path": "/api/completions",
           "file": "server/index.js",
-          "line": 621,
+          "line": 673,
           "op": "INSERT",
           "filtersByOrgId": false
         }
@@ -2665,7 +2816,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 299,
+          "line": 330,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -2674,7 +2825,7 @@
           "method": "POST",
           "path": "/api/houses/seed",
           "file": "server/index.js",
-          "line": 460,
+          "line": 491,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -2683,7 +2834,7 @@
           "method": "POST",
           "path": "/api/products",
           "file": "server/index.js",
-          "line": 712,
+          "line": 809,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -2692,7 +2843,7 @@
           "method": "POST",
           "path": "/api/products/:id/purchase",
           "file": "server/index.js",
-          "line": 752,
+          "line": 849,
           "op": "UPDATE",
           "filtersByOrgId": true
         },
@@ -2701,7 +2852,7 @@
           "method": "DELETE",
           "path": "/api/products/:id",
           "file": "server/index.js",
-          "line": 769,
+          "line": 866,
           "op": "DELETE",
           "filtersByOrgId": true
         }
@@ -2746,7 +2897,7 @@
           "method": "GET",
           "path": "/api/shopping-categories",
           "file": "server/index.js",
-          "line": 781,
+          "line": 878,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2755,7 +2906,7 @@
           "method": "POST",
           "path": "/api/shopping-categories",
           "file": "server/index.js",
-          "line": 797,
+          "line": 894,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2764,7 +2915,7 @@
           "method": "GET",
           "path": "/api/shopping-items",
           "file": "server/index.js",
-          "line": 858,
+          "line": 955,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2773,7 +2924,7 @@
           "method": "GET",
           "path": "/api/shopping-items/history",
           "file": "server/index.js",
-          "line": 942,
+          "line": 1039,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2782,7 +2933,7 @@
           "method": "GET",
           "path": "/api/shopping-items/recommendations",
           "file": "server/index.js",
-          "line": 960,
+          "line": 1057,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -2793,7 +2944,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 301,
+          "line": 332,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -2802,7 +2953,7 @@
           "method": "POST",
           "path": "/api/shopping-categories",
           "file": "server/index.js",
-          "line": 801,
+          "line": 898,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -2811,7 +2962,7 @@
           "method": "DELETE",
           "path": "/api/shopping-categories/:id",
           "file": "server/index.js",
-          "line": 834,
+          "line": 931,
           "op": "DELETE",
           "filtersByOrgId": true
         }
@@ -2878,7 +3029,7 @@
           "method": "GET",
           "path": "/api/shopping-items",
           "file": "server/index.js",
-          "line": 858,
+          "line": 955,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2887,7 +3038,7 @@
           "method": "GET",
           "path": "/api/shopping-items/history",
           "file": "server/index.js",
-          "line": 942,
+          "line": 1039,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2896,7 +3047,7 @@
           "method": "GET",
           "path": "/api/shopping-items/recommendations",
           "file": "server/index.js",
-          "line": 960,
+          "line": 1057,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2905,7 +3056,7 @@
           "method": "GET",
           "path": "/api/shopping-items/recommendations",
           "file": "server/index.js",
-          "line": 971,
+          "line": 1068,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -2916,7 +3067,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 300,
+          "line": 331,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -2925,7 +3076,7 @@
           "method": "GET",
           "path": "/api/shopping-items",
           "file": "server/index.js",
-          "line": 847,
+          "line": 944,
           "op": "UPDATE",
           "filtersByOrgId": true
         },
@@ -2934,7 +3085,7 @@
           "method": "POST",
           "path": "/api/shopping-items",
           "file": "server/index.js",
-          "line": 876,
+          "line": 973,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -2943,7 +3094,7 @@
           "method": "DELETE",
           "path": "/api/shopping-items/clear-purchased",
           "file": "server/index.js",
-          "line": 922,
+          "line": 1019,
           "op": "UPDATE",
           "filtersByOrgId": true
         },
@@ -2952,7 +3103,7 @@
           "method": "DELETE",
           "path": "/api/shopping-items/:id",
           "file": "server/index.js",
-          "line": 988,
+          "line": 1085,
           "op": "DELETE",
           "filtersByOrgId": true
         }
@@ -2987,6 +3138,10 @@
             "type": "TEXT"
           },
           {
+            "name": "member_type",
+            "type": "TEXT"
+          },
+          {
             "name": "created_at",
             "type": "TIMESTAMPTZ"
           }
@@ -3010,7 +3165,7 @@
           "method": "GET",
           "path": "/api/houses/profile",
           "file": "server/index.js",
-          "line": 182,
+          "line": 212,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -3019,7 +3174,7 @@
           "method": "PUT",
           "path": "/api/houses/profile",
           "file": "server/index.js",
-          "line": 204,
+          "line": 235,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -3028,7 +3183,15 @@
           "method": "GET",
           "path": "/api/stats/participation",
           "file": "server/index.js",
-          "line": 1129,
+          "line": 1226,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "helper",
+          "helper": "requireHouse",
+          "file": "server/lib/middleware.js",
+          "line": 47,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -3036,10 +3199,19 @@
       "writers": [
         {
           "kind": "route",
+          "method": "PATCH",
+          "path": "/api/houses/members/:userId/type",
+          "file": "server/index.js",
+          "line": 195,
+          "op": "INSERT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
           "method": "PUT",
           "path": "/api/houses/profile",
           "file": "server/index.js",
-          "line": 212,
+          "line": 243,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -3048,8 +3220,69 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 302,
+          "line": 333,
           "op": "DELETE",
+          "filtersByOrgId": true
+        }
+      ]
+    },
+    "visits": {
+      "defined": true,
+      "schema": {
+        "columns": [
+          {
+            "name": "id",
+            "type": "UUID"
+          },
+          {
+            "name": "organization_id",
+            "type": "TEXT"
+          },
+          {
+            "name": "user_id",
+            "type": "TEXT"
+          },
+          {
+            "name": "visited_on",
+            "type": "DATE"
+          },
+          {
+            "name": "created_at",
+            "type": "TIMESTAMPTZ"
+          }
+        ],
+        "fks": [],
+        "hasOrgId": true,
+        "source": "db/init.sql"
+      },
+      "readers": [
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/completions",
+          "file": "server/index.js",
+          "line": 656,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/visits/active",
+          "file": "server/index.js",
+          "line": 708,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        }
+      ],
+      "writers": [
+        {
+          "kind": "route",
+          "method": "POST",
+          "path": "/api/visits",
+          "file": "server/index.js",
+          "line": 735,
+          "op": "INSERT",
           "filtersByOrgId": true
         }
       ]
@@ -3089,7 +3322,7 @@
           "kind": "helper",
           "helper": "requireSuperAdmin",
           "file": "server/lib/middleware.js",
-          "line": 68,
+          "line": 72,
           "op": "SELECT",
           "filtersByOrgId": false
         }
@@ -3139,7 +3372,7 @@
           "method": "GET",
           "path": "/api/plants",
           "file": "server/index.js",
-          "line": 1000,
+          "line": 1097,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -3148,7 +3381,7 @@
           "method": "POST",
           "path": "/api/plants/:id/water",
           "file": "server/index.js",
-          "line": 1067,
+          "line": 1164,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -3157,7 +3390,7 @@
           "method": "GET",
           "path": "/api/plants/:id/history",
           "file": "server/index.js",
-          "line": 1103,
+          "line": 1200,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -3168,7 +3401,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 304,
+          "line": 335,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -3177,7 +3410,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 308,
+          "line": 339,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -3186,7 +3419,7 @@
           "method": "POST",
           "path": "/api/plants",
           "file": "server/index.js",
-          "line": 1016,
+          "line": 1113,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -3195,7 +3428,7 @@
           "method": "PATCH",
           "path": "/api/plants/:id",
           "file": "server/index.js",
-          "line": 1035,
+          "line": 1132,
           "op": "UPDATE",
           "filtersByOrgId": true
         },
@@ -3204,7 +3437,7 @@
           "method": "DELETE",
           "path": "/api/plants/:id",
           "file": "server/index.js",
-          "line": 1051,
+          "line": 1148,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -3213,7 +3446,7 @@
           "method": "POST",
           "path": "/api/plants/:id/water",
           "file": "server/index.js",
-          "line": 1078,
+          "line": 1175,
           "op": "UPDATE",
           "filtersByOrgId": true
         }
@@ -3260,7 +3493,7 @@
           "method": "GET",
           "path": "/api/plants/:id/history",
           "file": "server/index.js",
-          "line": 1103,
+          "line": 1200,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -3271,7 +3504,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 304,
+          "line": 335,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -3280,7 +3513,7 @@
           "method": "POST",
           "path": "/api/plants/:id/water",
           "file": "server/index.js",
-          "line": 1074,
+          "line": 1171,
           "op": "INSERT",
           "filtersByOrgId": false
         }
@@ -3325,7 +3558,7 @@
         ],
         "fks": [],
         "hasOrgId": true,
-        "source": "server/index.js:1450"
+        "source": "server/index.js:1562"
       },
       "readers": [
         {
@@ -3333,7 +3566,7 @@
           "method": "GET",
           "path": "/api/push/status",
           "file": "server/index.js",
-          "line": 1250,
+          "line": 1347,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -3341,7 +3574,7 @@
           "kind": "helper",
           "helper": "sendPushToHouse",
           "file": "server/index.js",
-          "line": 1265,
+          "line": 1362,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -3352,7 +3585,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 303,
+          "line": 334,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -3361,7 +3594,7 @@
           "method": "POST",
           "path": "/api/push/subscribe",
           "file": "server/index.js",
-          "line": 1218,
+          "line": 1315,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -3370,7 +3603,7 @@
           "method": "DELETE",
           "path": "/api/push/subscribe",
           "file": "server/index.js",
-          "line": 1240,
+          "line": 1337,
           "op": "DELETE",
           "filtersByOrgId": false
         },
@@ -3378,7 +3611,7 @@
           "kind": "helper",
           "helper": "sendPushToHouse",
           "file": "server/index.js",
-          "line": 1279,
+          "line": 1376,
           "op": "DELETE",
           "filtersByOrgId": false
         }
@@ -3411,7 +3644,7 @@
           "method": "GET",
           "path": "/api/invitations",
           "file": "server/index.js",
-          "line": 228,
+          "line": 259,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -3447,7 +3680,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 312,
+          "line": 343,
           "op": "DELETE",
           "filtersByOrgId": false
         }
@@ -3486,10 +3719,19 @@
         },
         {
           "kind": "route",
+          "method": "PATCH",
+          "path": "/api/houses/members/:userId/type",
+          "file": "server/index.js",
+          "line": 188,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 285,
+          "line": 316,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -3508,7 +3750,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 311,
+          "line": 342,
           "op": "DELETE",
           "filtersByOrgId": true
         }
@@ -3523,7 +3765,7 @@
           "method": "GET",
           "path": "/api/invitations",
           "file": "server/index.js",
-          "line": 228,
+          "line": 259,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -3534,7 +3776,7 @@
           "method": "DELETE",
           "path": "/api/invitations/:id",
           "file": "server/index.js",
-          "line": 245,
+          "line": 276,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -3543,7 +3785,7 @@
           "method": "POST",
           "path": "/api/invitations/:id/renew",
           "file": "server/index.js",
-          "line": 261,
+          "line": 292,
           "op": "UPDATE",
           "filtersByOrgId": true
         },
@@ -3552,7 +3794,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 310,
+          "line": 341,
           "op": "DELETE",
           "filtersByOrgId": true
         }

--- a/db/init.sql
+++ b/db/init.sql
@@ -85,9 +85,22 @@ CREATE TABLE IF NOT EXISTS house_member_profiles (
     avatar          TEXT NOT NULL DEFAULT '🧑',
     color           TEXT NOT NULL DEFAULT '#6a9960',
     home_screen     TEXT NOT NULL DEFAULT 'tasks',
+    member_type     TEXT NOT NULL DEFAULT 'regular',
     created_at      TIMESTAMPTZ DEFAULT NOW(),
     UNIQUE(user_id, organization_id)
 );
+
+-- Visitas del personal externo: marca de llegada con la fecha real de la visita.
+-- Las tareas que complete un externo heredan esta fecha (nunca posterior a la visita).
+CREATE TABLE IF NOT EXISTS visits (
+    id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    organization_id TEXT NOT NULL,
+    user_id         TEXT NOT NULL,
+    visited_on      DATE NOT NULL,
+    created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_visits_org_user ON visits(organization_id, user_id, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS super_admins (
     id         UUID DEFAULT gen_random_uuid() PRIMARY KEY,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 > Este archivo se actualiza en cada iteración para rastrear el progreso contra el [Roadmap de Visión](../CLAUDE.md#roadmap-de-visión).
 
-## Estado Actual: Fase 0 (MVP) — COMPLETADA | Fase 1 — COMPLETADA | Fase 2 — EN PROGRESO
+## Estado Actual: Fase 0 (MVP) — COMPLETADA | Fase 1 — COMPLETADA | Fase 2 — EN PROGRESO | Fase 3 — INICIADA (gestión de personal)
+
+---
+
+## [Fase 3] — Monetización
+
+### 2026-06-11 — Rol "externo": marca de llegada + fecha heredada por las tareas
+- **Visión** — primera pieza del caso "hogares con servicio doméstico" (Tier Pro de la Fase 3). Permite que el personal de aseo registre su trabajo sin romper los contadores, base para la futura gestión y reportes de personal.
+- **Rol como flag de app** — se añadió `member_type` (`'regular'|'externo'`, default `'regular'`) a `house_member_profiles` en vez de tocar los roles nativos de better-auth, para no arriesgar el login. El externo sigue siendo `member` (no puede crear/editar/borrar tareas), pero gana flujo de visita y ve un menú reducido. `requireHouse` ahora resuelve `member_type` junto al `role` y lo expone en `req.house.memberType`.
+- **Marca de llegada (visitas)** — nueva tabla `visits` (`organization_id`, `user_id`, `visited_on DATE`). `POST /api/visits` (solo externo) registra la llegada con fecha por defecto hoy, editable a días pasados y **validada contra `CURRENT_DATE` para rechazar fechas futuras**. `GET /api/visits/active` devuelve la última visita del usuario en la casa.
+- **Fecha heredada, nunca posterior a la visita** — al completar una tarea, si el miembro es externo el backend ignora la fecha del cliente y usa la de su última visita (mediodía UTC del día, topado al momento actual). Si no marcó llegada, responde `400 "Marca tu llegada antes de registrar tareas"`. Así, cuando registran las tareas el día después, los contadores (`isTaskPending`, stats por `DATE(completed_at)`) no se corren.
+- **Gestión desde Configuración** — `PATCH /api/houses/members/:userId/type` (owner/admin) marca/desmarca a un miembro como externo (no permite cambiar al dueño). En `HouseSettings` cada miembro no-dueño gana un toggle "Externo" con badge clay; el resto de miembros muestra el badge si aplica.
+- **Frontend del externo** — `Home` detecta su `member_type` y muestra el `ArrivalBanner` (marcar/ajustar fecha de visita, resumen "Hoy/Ayer/Hace N días") y bloquea el marcado con un aviso si aún no marcó llegada. `Layout` reduce el menú a solo *Tareas* y `HouseSettings` oculta el selector de pantalla de inicio para el externo.
+- **Tests** — backend 71/71 (nuevo caso de `member_type` en `requireHouse`), frontend 163/163, build de Vite verde (434 kB). Code graph regenerado.
+- Archivos: `db/init.sql`, `server/index.js`, `server/lib/middleware.js`, `server/lib/middleware.test.js`, `frontend/src/lib/api.js`, `frontend/src/pages/Home.jsx`, `frontend/src/components/ArrivalBanner.jsx` (nuevo), `frontend/src/components/Layout.jsx`, `frontend/src/pages/HouseSettings.jsx`.
 
 ---
 

--- a/docs/CODE_GRAPH.md
+++ b/docs/CODE_GRAPH.md
@@ -1,6 +1,6 @@
 # Code Graph — Casa Limpia
 
-_Generado automaticamente por `scripts/codegraph.js` el 2026-05-27T23:26:31.706Z._
+_Generado automaticamente por `scripts/codegraph.js` el 2026-06-11T00:15:06.321Z._
 
 **No editar a mano.** Regenerar con `npm run codegraph` despues de cambios en `server/` o `db/init.sql`.
 
@@ -8,20 +8,20 @@ _Generado automaticamente por `scripts/codegraph.js` el 2026-05-27T23:26:31.706Z
 
 | Metrica | Valor |
 |---|---|
-| Rutas registradas | 50 |
-| Queries en rutas (estaticas) | 78 |
+| Rutas registradas | 53 |
+| Queries en rutas (estaticas) | 84 |
 | Queries dinamicas (SQL en variable) | 6 |
-| Queries con filtro `organization_id` | 59 |
+| Queries con filtro `organization_id` | 64 |
 | Helpers con queries | 5 |
-| Tablas en schema | 10 |
-| Tablas referenciadas (incl. externas) | 14 |
+| Tablas en schema | 11 |
+| Tablas referenciadas (incl. externas) | 15 |
 
 ## Queries sin filtro multi-tenant (revisar)
 
 Queries que tocan tablas con `organization_id` pero no lo filtran:
 
 - `GET /api/super-admin/stats` (server/index.js:107) — SELECT `tasks`
-- `DELETE /api/push/subscribe` (server/index.js:1240) — DELETE `push_subscriptions`
+- `DELETE /api/push/subscribe` (server/index.js:1337) — DELETE `push_subscriptions`
 
 ## API → Handler → SQL
 
@@ -33,25 +33,26 @@ Queries que tocan tablas con `organization_id` pero no lo filtran:
 
 ### /api/completions
 
-**`GET /api/completions`** — server/index.js:596 _[requireAuth, requireHouse]_
+**`GET /api/completions`** — server/index.js:627 _[requireAuth, requireHouse]_
 
-- [OK] L598 SELECT → `completions, tasks`
+- [OK] L629 SELECT → `completions, tasks`
 
-**`POST /api/completions`** — server/index.js:612 _[requireAuth, requireHouse]_
+**`POST /api/completions`** — server/index.js:643 _[requireAuth, requireHouse]_
 
-- [OK] L616 SELECT → `tasks`
--      L621 INSERT → `completions`
-- [OK] L628 UPDATE → `tasks`
+- [OK] L647 SELECT → `tasks`
+- [OK] L656 SELECT → `visits`
+-      L673 INSERT → `completions`
+- [OK] L680 UPDATE → `tasks`
 
-**`GET /api/completions/:taskId/history`** — server/index.js:666 _[requireAuth, requireHouse]_
+**`GET /api/completions/:taskId/history`** — server/index.js:763 _[requireAuth, requireHouse]_
 
-- [OK] L669 SELECT → `completions, tasks`
+- [OK] L766 SELECT → `completions, tasks`
 
 ### /api/health
 
-**`GET /api/health`** — server/index.js:473
+**`GET /api/health`** — server/index.js:504
 
--      L475 SELECT
+-      L506 SELECT
 
 ### /api/houses
 
@@ -59,183 +60,188 @@ Queries que tocan tablas con `organization_id` pero no lo filtran:
 
 - [OK] L160 SELECT → `member, user, house_member_profiles`
 
-**`GET /api/houses/profile`** — server/index.js:180 _[requireAuth, requireHouse]_
+**`PATCH /api/houses/members/:userId/type`** — server/index.js:181 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
-- [OK] L182 SELECT → `house_member_profiles`
+-      L188 SELECT → `member`
+- [OK] L195 INSERT → `house_member_profiles`
 
-**`PUT /api/houses/profile`** — server/index.js:198 _[requireAuth, requireHouse]_
+**`GET /api/houses/profile`** — server/index.js:210 _[requireAuth, requireHouse]_
 
-- [OK] L204 SELECT → `house_member_profiles`
-- [OK] L212 INSERT → `house_member_profiles`
+- [OK] L212 SELECT → `house_member_profiles`
 
-**`DELETE /api/houses/:id`** — server/index.js:278 _[requireAuth]_
+**`PUT /api/houses/profile`** — server/index.js:229 _[requireAuth, requireHouse]_
 
--      L285 SELECT → `member`
--      L296 BEGIN
-- [OK] L298 DELETE → `tasks`
-- [OK] L299 DELETE → `products`
-- [OK] L300 DELETE → `shopping_items`
-- [OK] L301 DELETE → `shopping_categories`
-- [OK] L302 DELETE → `house_member_profiles`
-- [OK] L303 DELETE → `push_subscriptions`
-- [OK] L304 DELETE → `plant_watering_history, plants`
-- [OK] L308 DELETE → `plants`
--      L310 DELETE → `invitation`
--      L311 DELETE → `member`
--      L312 DELETE → `organization`
--      L313 COMMIT
--      L317 ROLLBACK
+- [OK] L235 SELECT → `house_member_profiles`
+- [OK] L243 INSERT → `house_member_profiles`
 
-**`POST /api/houses/seed`** — server/index.js:325 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`DELETE /api/houses/:id`** — server/index.js:309 _[requireAuth]_
 
-- [OK] L332 SELECT → `tasks`
-- [OK] L368 INSERT → `tasks`
-- [OK] L404 INSERT → `tasks`
-- [OK] L460 INSERT → `products`
+-      L316 SELECT → `member`
+-      L327 BEGIN
+- [OK] L329 DELETE → `tasks`
+- [OK] L330 DELETE → `products`
+- [OK] L331 DELETE → `shopping_items`
+- [OK] L332 DELETE → `shopping_categories`
+- [OK] L333 DELETE → `house_member_profiles`
+- [OK] L334 DELETE → `push_subscriptions`
+- [OK] L335 DELETE → `plant_watering_history, plants`
+- [OK] L339 DELETE → `plants`
+-      L341 DELETE → `invitation`
+-      L342 DELETE → `member`
+-      L343 DELETE → `organization`
+-      L344 COMMIT
+-      L348 ROLLBACK
+
+**`POST /api/houses/seed`** — server/index.js:356 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+
+- [OK] L363 SELECT → `tasks`
+- [OK] L399 INSERT → `tasks`
+- [OK] L435 INSERT → `tasks`
+- [OK] L491 INSERT → `products`
 
 ### /api/invitations
 
-**`GET /api/invitations`** — server/index.js:226 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`GET /api/invitations`** — server/index.js:257 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
--      L228 SELECT → `invitation, user`
+-      L259 SELECT → `invitation, user`
 
-**`DELETE /api/invitations/:id`** — server/index.js:243 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`DELETE /api/invitations/:id`** — server/index.js:274 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
--      L245 DELETE → `invitation`
+-      L276 DELETE → `invitation`
 
-**`POST /api/invitations/:id/renew`** — server/index.js:259 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`POST /api/invitations/:id/renew`** — server/index.js:290 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
--      L261 UPDATE → `invitation`
+-      L292 UPDATE → `invitation`
 
 ### /api/plants
 
-**`GET /api/plants`** — server/index.js:998 _[requireAuth, requireHouse]_
+**`GET /api/plants`** — server/index.js:1095 _[requireAuth, requireHouse]_
 
-- [OK] L1000 SELECT → `plants`
+- [OK] L1097 SELECT → `plants`
 
-**`POST /api/plants`** — server/index.js:1011 _[requireAuth, requireHouse]_
+**`POST /api/plants`** — server/index.js:1108 _[requireAuth, requireHouse]_
 
-- [OK] L1016 INSERT → `plants`
+- [OK] L1113 INSERT → `plants`
 
-**`PATCH /api/plants/:id`** — server/index.js:1028 _[requireAuth, requireHouse]_
+**`PATCH /api/plants/:id`** — server/index.js:1125 _[requireAuth, requireHouse]_
 
-- [OK] L1035 UPDATE → `plants`
+- [OK] L1132 UPDATE → `plants`
 
-**`DELETE /api/plants/:id`** — server/index.js:1048 _[requireAuth, requireHouse]_
+**`DELETE /api/plants/:id`** — server/index.js:1145 _[requireAuth, requireHouse]_
 
-- [OK] L1051 DELETE → `plants`
+- [OK] L1148 DELETE → `plants`
 
-**`POST /api/plants/:id/water`** — server/index.js:1063 _[requireAuth, requireHouse]_
+**`POST /api/plants/:id/water`** — server/index.js:1160 _[requireAuth, requireHouse]_
 
-- [OK] L1067 SELECT → `plants`
--      L1073 BEGIN
--      L1074 INSERT → `plant_watering_history`
-- [OK] L1078 UPDATE → `plants`
--      L1082 COMMIT
--      L1092 ROLLBACK
+- [OK] L1164 SELECT → `plants`
+-      L1170 BEGIN
+-      L1171 INSERT → `plant_watering_history`
+- [OK] L1175 UPDATE → `plants`
+-      L1179 COMMIT
+-      L1189 ROLLBACK
 
-**`GET /api/plants/:id/history`** — server/index.js:1100 _[requireAuth, requireHouse]_
+**`GET /api/plants/:id/history`** — server/index.js:1197 _[requireAuth, requireHouse]_
 
-- [OK] L1103 SELECT → `plant_watering_history, plants`
+- [OK] L1200 SELECT → `plant_watering_history, plants`
 
 ### /api/products
 
-**`GET /api/products`** — server/index.js:684 _[requireAuth, requireHouse]_
+**`GET /api/products`** — server/index.js:781 _[requireAuth, requireHouse]_
 
-- L700 _dynamic SQL (`pool.query(variable)`)_
+- L797 _dynamic SQL (`pool.query(variable)`)_
 
-**`POST /api/products`** — server/index.js:708 _[requireAuth, requireHouse]_
+**`POST /api/products`** — server/index.js:805 _[requireAuth, requireHouse]_
 
-- [OK] L712 INSERT → `products`
+- [OK] L809 INSERT → `products`
 
-**`PATCH /api/products/:id`** — server/index.js:724 _[requireAuth, requireHouse]_
+**`PATCH /api/products/:id`** — server/index.js:821 _[requireAuth, requireHouse]_
 
-- L740 _dynamic SQL (`pool.query(variable)`)_
+- L837 _dynamic SQL (`pool.query(variable)`)_
 
-**`POST /api/products/:id/purchase`** — server/index.js:749 _[requireAuth, requireHouse]_
+**`POST /api/products/:id/purchase`** — server/index.js:846 _[requireAuth, requireHouse]_
 
-- [OK] L752 UPDATE → `products`
+- [OK] L849 UPDATE → `products`
 
-**`DELETE /api/products/:id`** — server/index.js:766 _[requireAuth, requireHouse]_
+**`DELETE /api/products/:id`** — server/index.js:863 _[requireAuth, requireHouse]_
 
-- [OK] L769 DELETE → `products`
+- [OK] L866 DELETE → `products`
 
 ### /api/push
 
-**`GET /api/push/vapid-key`** — server/index.js:1204
+**`GET /api/push/vapid-key`** — server/index.js:1301
 
 - _Sin queries directas._
 
-**`POST /api/push/subscribe`** — server/index.js:1211 _[requireAuth, requireHouse]_
+**`POST /api/push/subscribe`** — server/index.js:1308 _[requireAuth, requireHouse]_
 
-- [OK] L1218 INSERT → `push_subscriptions`
+- [OK] L1315 INSERT → `push_subscriptions`
 
-**`DELETE /api/push/subscribe`** — server/index.js:1236 _[requireAuth]_
+**`DELETE /api/push/subscribe`** — server/index.js:1333 _[requireAuth]_
 
-- [!!] L1240 DELETE → `push_subscriptions`
+- [!!] L1337 DELETE → `push_subscriptions`
 
-**`GET /api/push/status`** — server/index.js:1248 _[requireAuth, requireHouse]_
+**`GET /api/push/status`** — server/index.js:1345 _[requireAuth, requireHouse]_
 
-- [OK] L1250 SELECT → `push_subscriptions`
+- [OK] L1347 SELECT → `push_subscriptions`
 
 ### /api/shopping-categories
 
-**`GET /api/shopping-categories`** — server/index.js:779 _[requireAuth, requireHouse]_
+**`GET /api/shopping-categories`** — server/index.js:876 _[requireAuth, requireHouse]_
 
-- [OK] L781 SELECT → `shopping_categories`
+- [OK] L878 SELECT → `shopping_categories`
 
-**`POST /api/shopping-categories`** — server/index.js:792 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`POST /api/shopping-categories`** — server/index.js:889 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
-- [OK] L797 SELECT → `shopping_categories`
-- [OK] L801 INSERT → `shopping_categories`
+- [OK] L894 SELECT → `shopping_categories`
+- [OK] L898 INSERT → `shopping_categories`
 
-**`PATCH /api/shopping-categories/:id`** — server/index.js:812 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`PATCH /api/shopping-categories/:id`** — server/index.js:909 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
-- L822 _dynamic SQL (`pool.query(variable)`)_
+- L919 _dynamic SQL (`pool.query(variable)`)_
 
-**`DELETE /api/shopping-categories/:id`** — server/index.js:831 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`DELETE /api/shopping-categories/:id`** — server/index.js:928 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
-- [OK] L834 DELETE → `shopping_categories`
+- [OK] L931 DELETE → `shopping_categories`
 
 ### /api/shopping-items
 
-**`GET /api/shopping-items`** — server/index.js:844 _[requireAuth, requireHouse]_
+**`GET /api/shopping-items`** — server/index.js:941 _[requireAuth, requireHouse]_
 
-- [OK] L847 UPDATE → `shopping_items`
-- [OK] L858 SELECT → `shopping_items, shopping_categories`
+- [OK] L944 UPDATE → `shopping_items`
+- [OK] L955 SELECT → `shopping_items, shopping_categories`
 
-**`POST /api/shopping-items`** — server/index.js:872 _[requireAuth, requireHouse]_
+**`POST /api/shopping-items`** — server/index.js:969 _[requireAuth, requireHouse]_
 
-- [OK] L876 INSERT → `shopping_items`
+- [OK] L973 INSERT → `shopping_items`
 
-**`PATCH /api/shopping-items/:id`** — server/index.js:887 _[requireAuth, requireHouse]_
+**`PATCH /api/shopping-items/:id`** — server/index.js:984 _[requireAuth, requireHouse]_
 
-- L909 _dynamic SQL (`pool.query(variable)`)_
+- L1006 _dynamic SQL (`pool.query(variable)`)_
 
-**`DELETE /api/shopping-items/clear-purchased`** — server/index.js:919 _[requireAuth, requireHouse]_
+**`DELETE /api/shopping-items/clear-purchased`** — server/index.js:1016 _[requireAuth, requireHouse]_
 
-- [OK] L922 UPDATE → `shopping_items`
+- [OK] L1019 UPDATE → `shopping_items`
 
-**`GET /api/shopping-items/history`** — server/index.js:939 _[requireAuth, requireHouse]_
+**`GET /api/shopping-items/history`** — server/index.js:1036 _[requireAuth, requireHouse]_
 
-- [OK] L942 SELECT → `shopping_items, shopping_categories`
+- [OK] L1039 SELECT → `shopping_items, shopping_categories`
 
-**`GET /api/shopping-items/recommendations`** — server/index.js:958 _[requireAuth, requireHouse]_
+**`GET /api/shopping-items/recommendations`** — server/index.js:1055 _[requireAuth, requireHouse]_
 
-- [OK] L960 SELECT → `shopping_items, shopping_categories`
-- [OK] L971 SELECT → `shopping_items`
+- [OK] L1057 SELECT → `shopping_items, shopping_categories`
+- [OK] L1068 SELECT → `shopping_items`
 
-**`DELETE /api/shopping-items/:id`** — server/index.js:985 _[requireAuth, requireHouse]_
+**`DELETE /api/shopping-items/:id`** — server/index.js:1082 _[requireAuth, requireHouse]_
 
-- [OK] L988 DELETE → `shopping_items`
+- [OK] L1085 DELETE → `shopping_items`
 
 ### /api/stats
 
-**`GET /api/stats/participation`** — server/index.js:1118 _[requireAuth, requireHouse]_
+**`GET /api/stats/participation`** — server/index.js:1215 _[requireAuth, requireHouse]_
 
-- [OK] L1129 SELECT → `completions, tasks, house_member_profiles`
-- [OK] L1149 SELECT → `completions, tasks`
-- [OK] L1162 SELECT → `completions, tasks`
+- [OK] L1226 SELECT → `completions, tasks, house_member_profiles`
+- [OK] L1246 SELECT → `completions, tasks`
+- [OK] L1259 SELECT → `completions, tasks`
 
 ### /api/super-admin
 
@@ -255,92 +261,105 @@ Queries que tocan tablas con `organization_id` pero no lo filtran:
 
 ### /api/tasks
 
-**`GET /api/tasks/pending`** — server/index.js:501 _[requireAuth, requireHouse]_
+**`GET /api/tasks/pending`** — server/index.js:532 _[requireAuth, requireHouse]_
 
-- [OK] L503 SELECT → `tasks, completions`
+- [OK] L534 SELECT → `tasks, completions`
 
-**`GET /api/tasks`** — server/index.js:527 _[requireAuth, requireHouse]_
+**`GET /api/tasks`** — server/index.js:558 _[requireAuth, requireHouse]_
 
-- L533 _dynamic SQL (`pool.query(variable)`)_
+- L564 _dynamic SQL (`pool.query(variable)`)_
 
-**`POST /api/tasks`** — server/index.js:541 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`POST /api/tasks`** — server/index.js:572 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
-- [OK] L544 INSERT → `tasks`
+- [OK] L575 INSERT → `tasks`
 
-**`PATCH /api/tasks/:id`** — server/index.js:556 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`PATCH /api/tasks/:id`** — server/index.js:587 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
-- L566 _dynamic SQL (`pool.query(variable)`)_
+- L597 _dynamic SQL (`pool.query(variable)`)_
 
-**`DELETE /api/tasks/:id`** — server/index.js:575 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`DELETE /api/tasks/:id`** — server/index.js:606 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
-- [OK] L578 SELECT → `tasks`
--      L585 DELETE → `completions`
-- [OK] L586 DELETE → `tasks`
+- [OK] L609 SELECT → `tasks`
+-      L616 DELETE → `completions`
+- [OK] L617 DELETE → `tasks`
 
-**`POST /api/tasks/:id/reset`** — server/index.js:651 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`POST /api/tasks/:id/reset`** — server/index.js:748 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
-- [OK] L654 UPDATE → `tasks`
+- [OK] L751 UPDATE → `tasks`
 
 ### /api/uploads
 
-**`POST /api/uploads`** — server/index.js:484 _[requireAuth, upload.single('image')]_
+**`POST /api/uploads`** — server/index.js:515 _[requireAuth, upload.single('image')]_
 
 - _Sin queries directas._
 
-**`DELETE /api/uploads/:filename`** — server/index.js:489 _[requireAuth]_
+**`DELETE /api/uploads/:filename`** — server/index.js:520 _[requireAuth]_
 
 - _Sin queries directas._
+
+### /api/visits
+
+**`GET /api/visits/active`** — server/index.js:706 _[requireAuth, requireHouse]_
+
+- [OK] L708 SELECT → `visits`
+
+**`POST /api/visits`** — server/index.js:722 _[requireAuth, requireHouse]_
+
+-      L731 SELECT
+- [OK] L735 INSERT → `visits`
 
 ## Helpers / factories con queries
 
-**`sendPushToHouse`** — server/index.js:1261
+**`sendPushToHouse`** — server/index.js:1358
 
-- L1265 SELECT → `push_subscriptions` (filtra org)
-- L1279 DELETE → `push_subscriptions`
+- L1362 SELECT → `push_subscriptions` (filtra org)
+- L1376 DELETE → `push_subscriptions`
 
-**`migrate`** — server/index.js:1291
+**`migrate`** — server/index.js:1388
 
-- L1294 CREATE (filtra org)
-- L1309 CREATE
-- L1318 CREATE
-- L1319 CREATE
-- L1321 CREATE (filtra org)
-- L1333 CREATE
-- L1334 CREATE
-- L1336 CREATE (filtra org)
-- L1346 CREATE (filtra org)
-- L1348 CREATE (filtra org)
-- L1360 CREATE
-- L1361 CREATE
-- L1383 CREATE (filtra org)
-- L1384 CREATE (filtra org)
-- L1385 CREATE (filtra org)
-- L1389 CREATE
-- L1397 CREATE
-- L1398 CREATE
-- L1401 CREATE (filtra org)
+- L1391 CREATE (filtra org)
+- L1406 CREATE
 - L1415 CREATE
-- L1424 CREATE (filtra org)
-- L1435 CREATE (filtra org)
-- L1437 CREATE
-- L1446 CREATE
-- L1447 CREATE
-- L1450 CREATE (filtra org)
-- L1462 CREATE (filtra org)
-- L1463 CREATE
+- L1416 CREATE
+- L1418 CREATE (filtra org)
+- L1430 CREATE
+- L1431 CREATE
+- L1433 CREATE (filtra org)
+- L1443 CREATE (filtra org)
+- L1445 CREATE (filtra org)
+- L1457 CREATE
+- L1458 CREATE
+- L1480 CREATE (filtra org)
+- L1481 CREATE (filtra org)
+- L1482 CREATE (filtra org)
+- L1486 CREATE
+- L1497 CREATE
+- L1498 CREATE
+- L1501 CREATE (filtra org)
+- L1515 CREATE (filtra org)
+- L1524 CREATE (filtra org)
+- L1527 CREATE
+- L1536 CREATE (filtra org)
+- L1547 CREATE (filtra org)
+- L1549 CREATE
+- L1558 CREATE
+- L1559 CREATE
+- L1562 CREATE (filtra org)
+- L1574 CREATE (filtra org)
+- L1575 CREATE
 
-**`addColumnIfMissing`** — server/index.js:1471
+**`addColumnIfMissing`** — server/index.js:1583
 
-- L1472 SELECT
-- L1477 ALTER
+- L1584 SELECT
+- L1589 ALTER
 
 **`requireHouse`** — server/lib/middleware.js:42
 
-- L47 SELECT → `member` (filtra org)
+- L47 SELECT → `member, house_member_profiles` (filtra org)
 
-**`requireSuperAdmin`** — server/lib/middleware.js:66
+**`requireSuperAdmin`** — server/lib/middleware.js:70
 
-- L68 SELECT → `super_admins`
+- L72 SELECT → `super_admins`
 
 ## Tablas → Endpoints
 
@@ -353,48 +372,51 @@ Queries que tocan tablas con `organization_id` pero no lo filtran:
     - `GET /api/super-admin/stats` (server/index.js:108, SELECT) [sin filtro org]
     - `GET /api/super-admin/stats` (server/index.js:109, SELECT) [sin filtro org]
     - `GET /api/super-admin/stats` (server/index.js:116, SELECT)
-    - `GET /api/tasks/pending` (server/index.js:503, SELECT)
-    - `GET /api/completions` (server/index.js:598, SELECT)
-    - `GET /api/completions/:taskId/history` (server/index.js:669, SELECT)
-    - `GET /api/stats/participation` (server/index.js:1129, SELECT)
-    - `GET /api/stats/participation` (server/index.js:1149, SELECT)
-    - `GET /api/stats/participation` (server/index.js:1162, SELECT)
+    - `GET /api/tasks/pending` (server/index.js:534, SELECT)
+    - `GET /api/completions` (server/index.js:629, SELECT)
+    - `GET /api/completions/:taskId/history` (server/index.js:766, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1226, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1246, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1259, SELECT)
 - **Escritores (2):**
-    - `DELETE /api/tasks/:id` (server/index.js:585, DELETE) [sin filtro org]
-    - `POST /api/completions` (server/index.js:621, INSERT) [sin filtro org]
+    - `DELETE /api/tasks/:id` (server/index.js:616, DELETE) [sin filtro org]
+    - `POST /api/completions` (server/index.js:673, INSERT) [sin filtro org]
 
 ### `house_member_profiles`
 
-- **Columnas:** `id` UUID, `user_id` TEXT, `organization_id` TEXT, `avatar` TEXT, `color` TEXT, `home_screen` TEXT, `created_at` TIMESTAMPTZ
+- **Columnas:** `id` UUID, `user_id` TEXT, `organization_id` TEXT, `avatar` TEXT, `color` TEXT, `home_screen` TEXT, `member_type` TEXT, `created_at` TIMESTAMPTZ
 - **Multi-tenant:** si (organization_id)
-- **Lectores (4):**
+- **Lectores (5):**
     - `GET /api/houses/members` (server/index.js:160, SELECT)
-    - `GET /api/houses/profile` (server/index.js:182, SELECT)
-    - `PUT /api/houses/profile` (server/index.js:204, SELECT)
-    - `GET /api/stats/participation` (server/index.js:1129, SELECT)
-- **Escritores (2):**
-    - `PUT /api/houses/profile` (server/index.js:212, INSERT)
-    - `DELETE /api/houses/:id` (server/index.js:302, DELETE)
+    - `GET /api/houses/profile` (server/index.js:212, SELECT)
+    - `PUT /api/houses/profile` (server/index.js:235, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1226, SELECT)
+    - helper `requireHouse` (server/lib/middleware.js:47, SELECT)
+- **Escritores (3):**
+    - `PATCH /api/houses/members/:userId/type` (server/index.js:195, INSERT)
+    - `PUT /api/houses/profile` (server/index.js:243, INSERT)
+    - `DELETE /api/houses/:id` (server/index.js:333, DELETE)
 
 ### `invitation` _(externa — better-auth u otra fuente)_
 
 - **Lectores (1):**
-    - `GET /api/invitations` (server/index.js:228, SELECT)
+    - `GET /api/invitations` (server/index.js:259, SELECT)
 - **Escritores (3):**
-    - `DELETE /api/invitations/:id` (server/index.js:245, DELETE)
-    - `POST /api/invitations/:id/renew` (server/index.js:261, UPDATE)
-    - `DELETE /api/houses/:id` (server/index.js:310, DELETE)
+    - `DELETE /api/invitations/:id` (server/index.js:276, DELETE)
+    - `POST /api/invitations/:id/renew` (server/index.js:292, UPDATE)
+    - `DELETE /api/houses/:id` (server/index.js:341, DELETE)
 
 ### `member` _(externa — better-auth u otra fuente)_
 
-- **Lectores (5):**
+- **Lectores (6):**
     - `GET /api/super-admin/stats` (server/index.js:106, SELECT) [sin filtro org]
     - `GET /api/super-admin/stats` (server/index.js:116, SELECT)
     - `GET /api/houses/members` (server/index.js:160, SELECT)
-    - `DELETE /api/houses/:id` (server/index.js:285, SELECT)
+    - `PATCH /api/houses/members/:userId/type` (server/index.js:188, SELECT)
+    - `DELETE /api/houses/:id` (server/index.js:316, SELECT)
     - helper `requireHouse` (server/lib/middleware.js:47, SELECT)
 - **Escritores (1):**
-    - `DELETE /api/houses/:id` (server/index.js:311, DELETE)
+    - `DELETE /api/houses/:id` (server/index.js:342, DELETE)
 
 ### `organization` _(externa — better-auth u otra fuente)_
 
@@ -402,7 +424,7 @@ Queries que tocan tablas con `organization_id` pero no lo filtran:
     - `GET /api/super-admin/stats` (server/index.js:105, SELECT) [sin filtro org]
     - `GET /api/super-admin/stats` (server/index.js:116, SELECT)
 - **Escritores (1):**
-    - `DELETE /api/houses/:id` (server/index.js:312, DELETE) [sin filtro org]
+    - `DELETE /api/houses/:id` (server/index.js:343, DELETE) [sin filtro org]
 
 ### `plant_watering_history`
 
@@ -410,65 +432,65 @@ Queries que tocan tablas con `organization_id` pero no lo filtran:
 - **FK:** `plant_id` → `plants.id`
 - **Multi-tenant:** no
 - **Lectores (1):**
-    - `GET /api/plants/:id/history` (server/index.js:1103, SELECT)
+    - `GET /api/plants/:id/history` (server/index.js:1200, SELECT)
 - **Escritores (2):**
-    - `DELETE /api/houses/:id` (server/index.js:304, DELETE)
-    - `POST /api/plants/:id/water` (server/index.js:1074, INSERT) [sin filtro org]
+    - `DELETE /api/houses/:id` (server/index.js:335, DELETE)
+    - `POST /api/plants/:id/water` (server/index.js:1171, INSERT) [sin filtro org]
 
 ### `plants`
 
 - **Columnas:** `id` UUID, `name` TEXT, `notes` TEXT, `watering_frequency_days` INTEGER, `last_watered_at` TIMESTAMPTZ, `organization_id` TEXT, `created_at` TIMESTAMPTZ
 - **Multi-tenant:** si (organization_id)
 - **Lectores (3):**
-    - `GET /api/plants` (server/index.js:1000, SELECT)
-    - `POST /api/plants/:id/water` (server/index.js:1067, SELECT)
-    - `GET /api/plants/:id/history` (server/index.js:1103, SELECT)
+    - `GET /api/plants` (server/index.js:1097, SELECT)
+    - `POST /api/plants/:id/water` (server/index.js:1164, SELECT)
+    - `GET /api/plants/:id/history` (server/index.js:1200, SELECT)
 - **Escritores (6):**
-    - `DELETE /api/houses/:id` (server/index.js:304, DELETE)
-    - `DELETE /api/houses/:id` (server/index.js:308, DELETE)
-    - `POST /api/plants` (server/index.js:1016, INSERT)
-    - `PATCH /api/plants/:id` (server/index.js:1035, UPDATE)
-    - `DELETE /api/plants/:id` (server/index.js:1051, DELETE)
-    - `POST /api/plants/:id/water` (server/index.js:1078, UPDATE)
+    - `DELETE /api/houses/:id` (server/index.js:335, DELETE)
+    - `DELETE /api/houses/:id` (server/index.js:339, DELETE)
+    - `POST /api/plants` (server/index.js:1113, INSERT)
+    - `PATCH /api/plants/:id` (server/index.js:1132, UPDATE)
+    - `DELETE /api/plants/:id` (server/index.js:1148, DELETE)
+    - `POST /api/plants/:id/water` (server/index.js:1175, UPDATE)
 
 ### `products`
 
 - **Columnas:** `id` UUID, `name` TEXT, `category` TEXT, `is_out_of_stock` BOOLEAN, `reminder_frequency_days` INTEGER, `units` INTEGER, `last_purchased_at` TIMESTAMPTZ, `last_out_of_stock_at` TIMESTAMPTZ, `organization_id` TEXT, `created_at` TIMESTAMPTZ
 - **Multi-tenant:** si (organization_id)
 - **Escritores (5):**
-    - `DELETE /api/houses/:id` (server/index.js:299, DELETE)
-    - `POST /api/houses/seed` (server/index.js:460, INSERT)
-    - `POST /api/products` (server/index.js:712, INSERT)
-    - `POST /api/products/:id/purchase` (server/index.js:752, UPDATE)
-    - `DELETE /api/products/:id` (server/index.js:769, DELETE)
+    - `DELETE /api/houses/:id` (server/index.js:330, DELETE)
+    - `POST /api/houses/seed` (server/index.js:491, INSERT)
+    - `POST /api/products` (server/index.js:809, INSERT)
+    - `POST /api/products/:id/purchase` (server/index.js:849, UPDATE)
+    - `DELETE /api/products/:id` (server/index.js:866, DELETE)
 
 ### `push_subscriptions`
 
 - **Columnas:** `id` UUID, `user_id` TEXT, `organization_id` TEXT, `endpoint` TEXT, `keys_p256dh` TEXT, `keys_auth` TEXT, `created_at` TIMESTAMPTZ, `updated_at` TIMESTAMPTZ
 - **Multi-tenant:** si (organization_id)
 - **Lectores (2):**
-    - `GET /api/push/status` (server/index.js:1250, SELECT)
-    - helper `sendPushToHouse` (server/index.js:1265, SELECT)
+    - `GET /api/push/status` (server/index.js:1347, SELECT)
+    - helper `sendPushToHouse` (server/index.js:1362, SELECT)
 - **Escritores (4):**
-    - `DELETE /api/houses/:id` (server/index.js:303, DELETE)
-    - `POST /api/push/subscribe` (server/index.js:1218, INSERT)
-    - `DELETE /api/push/subscribe` (server/index.js:1240, DELETE) [sin filtro org]
-    - helper `sendPushToHouse` (server/index.js:1279, DELETE) [sin filtro org]
+    - `DELETE /api/houses/:id` (server/index.js:334, DELETE)
+    - `POST /api/push/subscribe` (server/index.js:1315, INSERT)
+    - `DELETE /api/push/subscribe` (server/index.js:1337, DELETE) [sin filtro org]
+    - helper `sendPushToHouse` (server/index.js:1376, DELETE) [sin filtro org]
 
 ### `shopping_categories`
 
 - **Columnas:** `id` UUID, `name` TEXT, `emoji` TEXT, `sort_order` INTEGER, `organization_id` TEXT, `created_at` TIMESTAMPTZ
 - **Multi-tenant:** si (organization_id)
 - **Lectores (5):**
-    - `GET /api/shopping-categories` (server/index.js:781, SELECT)
-    - `POST /api/shopping-categories` (server/index.js:797, SELECT)
-    - `GET /api/shopping-items` (server/index.js:858, SELECT)
-    - `GET /api/shopping-items/history` (server/index.js:942, SELECT)
-    - `GET /api/shopping-items/recommendations` (server/index.js:960, SELECT)
+    - `GET /api/shopping-categories` (server/index.js:878, SELECT)
+    - `POST /api/shopping-categories` (server/index.js:894, SELECT)
+    - `GET /api/shopping-items` (server/index.js:955, SELECT)
+    - `GET /api/shopping-items/history` (server/index.js:1039, SELECT)
+    - `GET /api/shopping-items/recommendations` (server/index.js:1057, SELECT)
 - **Escritores (3):**
-    - `DELETE /api/houses/:id` (server/index.js:301, DELETE)
-    - `POST /api/shopping-categories` (server/index.js:801, INSERT)
-    - `DELETE /api/shopping-categories/:id` (server/index.js:834, DELETE)
+    - `DELETE /api/houses/:id` (server/index.js:332, DELETE)
+    - `POST /api/shopping-categories` (server/index.js:898, INSERT)
+    - `DELETE /api/shopping-categories/:id` (server/index.js:931, DELETE)
 
 ### `shopping_items`
 
@@ -476,16 +498,16 @@ Queries que tocan tablas con `organization_id` pero no lo filtran:
 - **FK:** `category_id` → `shopping_categories.id`
 - **Multi-tenant:** si (organization_id)
 - **Lectores (4):**
-    - `GET /api/shopping-items` (server/index.js:858, SELECT)
-    - `GET /api/shopping-items/history` (server/index.js:942, SELECT)
-    - `GET /api/shopping-items/recommendations` (server/index.js:960, SELECT)
-    - `GET /api/shopping-items/recommendations` (server/index.js:971, SELECT)
+    - `GET /api/shopping-items` (server/index.js:955, SELECT)
+    - `GET /api/shopping-items/history` (server/index.js:1039, SELECT)
+    - `GET /api/shopping-items/recommendations` (server/index.js:1057, SELECT)
+    - `GET /api/shopping-items/recommendations` (server/index.js:1068, SELECT)
 - **Escritores (5):**
-    - `DELETE /api/houses/:id` (server/index.js:300, DELETE)
-    - `GET /api/shopping-items` (server/index.js:847, UPDATE)
-    - `POST /api/shopping-items` (server/index.js:876, INSERT)
-    - `DELETE /api/shopping-items/clear-purchased` (server/index.js:922, UPDATE)
-    - `DELETE /api/shopping-items/:id` (server/index.js:988, DELETE)
+    - `DELETE /api/houses/:id` (server/index.js:331, DELETE)
+    - `GET /api/shopping-items` (server/index.js:944, UPDATE)
+    - `POST /api/shopping-items` (server/index.js:973, INSERT)
+    - `DELETE /api/shopping-items/clear-purchased` (server/index.js:1019, UPDATE)
+    - `DELETE /api/shopping-items/:id` (server/index.js:1085, DELETE)
 
 ### `super_admins`
 
@@ -493,7 +515,7 @@ Queries que tocan tablas con `organization_id` pero no lo filtran:
 - **Multi-tenant:** no
 - **Lectores (2):**
     - `GET /api/super-admin/check` (server/index.js:90, SELECT) [sin filtro org]
-    - helper `requireSuperAdmin` (server/lib/middleware.js:68, SELECT) [sin filtro org]
+    - helper `requireSuperAdmin` (server/lib/middleware.js:72, SELECT) [sin filtro org]
 
 ### `tasks`
 
@@ -502,28 +524,38 @@ Queries que tocan tablas con `organization_id` pero no lo filtran:
 - **Lectores (11):**
     - `GET /api/super-admin/stats` (server/index.js:107, SELECT) [sin filtro org]
     - `GET /api/super-admin/stats` (server/index.js:116, SELECT)
-    - `POST /api/houses/seed` (server/index.js:332, SELECT)
-    - `GET /api/tasks/pending` (server/index.js:503, SELECT)
-    - `DELETE /api/tasks/:id` (server/index.js:578, SELECT)
-    - `GET /api/completions` (server/index.js:598, SELECT)
-    - `POST /api/completions` (server/index.js:616, SELECT)
-    - `GET /api/completions/:taskId/history` (server/index.js:669, SELECT)
-    - `GET /api/stats/participation` (server/index.js:1129, SELECT)
-    - `GET /api/stats/participation` (server/index.js:1149, SELECT)
-    - `GET /api/stats/participation` (server/index.js:1162, SELECT)
+    - `POST /api/houses/seed` (server/index.js:363, SELECT)
+    - `GET /api/tasks/pending` (server/index.js:534, SELECT)
+    - `DELETE /api/tasks/:id` (server/index.js:609, SELECT)
+    - `GET /api/completions` (server/index.js:629, SELECT)
+    - `POST /api/completions` (server/index.js:647, SELECT)
+    - `GET /api/completions/:taskId/history` (server/index.js:766, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1226, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1246, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1259, SELECT)
 - **Escritores (7):**
-    - `DELETE /api/houses/:id` (server/index.js:298, DELETE)
-    - `POST /api/houses/seed` (server/index.js:368, INSERT)
-    - `POST /api/houses/seed` (server/index.js:404, INSERT)
-    - `POST /api/tasks` (server/index.js:544, INSERT)
-    - `DELETE /api/tasks/:id` (server/index.js:586, DELETE)
-    - `POST /api/completions` (server/index.js:628, UPDATE)
-    - `POST /api/tasks/:id/reset` (server/index.js:654, UPDATE)
+    - `DELETE /api/houses/:id` (server/index.js:329, DELETE)
+    - `POST /api/houses/seed` (server/index.js:399, INSERT)
+    - `POST /api/houses/seed` (server/index.js:435, INSERT)
+    - `POST /api/tasks` (server/index.js:575, INSERT)
+    - `DELETE /api/tasks/:id` (server/index.js:617, DELETE)
+    - `POST /api/completions` (server/index.js:680, UPDATE)
+    - `POST /api/tasks/:id/reset` (server/index.js:751, UPDATE)
 
 ### `user` _(externa — better-auth u otra fuente)_
 
 - **Lectores (3):**
     - `GET /api/super-admin/stats` (server/index.js:104, SELECT) [sin filtro org]
     - `GET /api/houses/members` (server/index.js:160, SELECT)
-    - `GET /api/invitations` (server/index.js:228, SELECT)
+    - `GET /api/invitations` (server/index.js:259, SELECT)
+
+### `visits`
+
+- **Columnas:** `id` UUID, `organization_id` TEXT, `user_id` TEXT, `visited_on` DATE, `created_at` TIMESTAMPTZ
+- **Multi-tenant:** si (organization_id)
+- **Lectores (2):**
+    - `POST /api/completions` (server/index.js:656, SELECT)
+    - `GET /api/visits/active` (server/index.js:708, SELECT)
+- **Escritores (1):**
+    - `POST /api/visits` (server/index.js:735, INSERT)
 

--- a/frontend/src/components/ArrivalBanner.jsx
+++ b/frontend/src/components/ArrivalBanner.jsx
@@ -1,0 +1,144 @@
+import { useState } from 'react'
+import { markVisit } from '../lib/api'
+
+function todayStr() {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function formatVisitDate(str) {
+  if (!str) return ''
+  const [y, m, d] = str.split('-').map(Number)
+  return new Date(y, m - 1, d).toLocaleDateString('es-ES', { weekday: 'long', day: 'numeric', month: 'long' })
+}
+
+function dayDiff(str) {
+  if (!str) return null
+  const [y, m, d] = str.split('-').map(Number)
+  const visit = new Date(y, m - 1, d)
+  const today = new Date()
+  visit.setHours(0, 0, 0, 0)
+  today.setHours(0, 0, 0, 0)
+  return Math.round((today - visit) / 86400000)
+}
+
+export default function ArrivalBanner({ visit, onMarked }) {
+  const today = todayStr()
+  const [editing, setEditing] = useState(!visit)
+  const [date, setDate] = useState(visit?.visited_on || today)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState(null)
+
+  async function handleMark() {
+    setSaving(true)
+    setError(null)
+    try {
+      const v = await markVisit(date)
+      onMarked(v)
+      setEditing(false)
+    } catch (err) {
+      setError(err.message || 'No se pudo marcar la llegada')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const diff = visit ? dayDiff(visit.visited_on) : null
+  const diffLabel = diff === 0 ? 'Hoy' : diff === 1 ? 'Ayer' : diff > 1 ? `Hace ${diff} días` : ''
+
+  // Estado: ya hay visita y no se está editando -> resumen compacto
+  if (visit && !editing) {
+    return (
+      <div
+        className="rounded-2xl p-4 mb-6 flex items-center gap-3"
+        style={{ background: 'rgba(106,153,96,0.08)', border: '1px solid rgba(106,153,96,0.25)' }}
+      >
+        <div
+          className="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0"
+          style={{ background: 'rgba(106,153,96,0.15)', color: 'var(--moss-500)' }}
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z" />
+            <circle cx="12" cy="10" r="3" />
+          </svg>
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="font-body text-[11px] font-semibold uppercase tracking-[0.1em]" style={{ color: 'var(--bark-300)' }}>
+            Visita registrada {diffLabel && `· ${diffLabel}`}
+          </p>
+          <p className="font-body font-semibold text-[14px] capitalize truncate" style={{ color: 'var(--bark-700)' }}>
+            {formatVisitDate(visit.visited_on)}
+          </p>
+        </div>
+        <button
+          onClick={() => { setDate(visit.visited_on); setEditing(true) }}
+          className="px-3 py-1.5 rounded-lg font-body font-semibold text-[12px] transition-all active:scale-95 flex-shrink-0"
+          style={{ color: 'var(--moss-500)', background: 'rgba(106,153,96,0.1)' }}
+        >
+          Cambiar
+        </button>
+      </div>
+    )
+  }
+
+  // Estado: marcar o ajustar la fecha de la visita
+  return (
+    <div
+      className="rounded-2xl p-4 mb-6"
+      style={{ background: 'var(--surface-card)', border: '1px solid rgba(184,90,58,0.25)' }}
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <div
+          className="w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0"
+          style={{ background: 'rgba(184,90,58,0.1)', color: 'var(--clay-500)' }}
+        >
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z" />
+            <circle cx="12" cy="10" r="3" />
+          </svg>
+        </div>
+        <div>
+          <h3 className="font-display text-[17px] leading-none" style={{ color: 'var(--bark-700)' }}>
+            Marca tu llegada
+          </h3>
+        </div>
+      </div>
+      <p className="font-body text-[12px] mb-3 leading-relaxed" style={{ color: 'var(--bark-300)' }}>
+        Las tareas que completes quedarán con la fecha de tu visita. Si registras otro día, ajusta la fecha. No puedes elegir una fecha futura.
+      </p>
+      <label className="font-body text-[11px] font-semibold uppercase tracking-wider mb-1.5 block" style={{ color: 'var(--bark-400)' }}>
+        Fecha de la visita
+      </label>
+      <input
+        type="date"
+        value={date}
+        max={today}
+        onChange={e => setDate(e.target.value)}
+        className="w-full px-3.5 py-2.5 rounded-xl font-body text-[16px] outline-none transition-all mb-3"
+        style={{ background: 'var(--surface-elevated)', border: '1.5px solid rgba(196,184,166,0.3)', color: 'var(--bark-700)' }}
+      />
+      {error && (
+        <p className="font-body text-[12px] mb-2" style={{ color: 'var(--clay-500)' }}>{error}</p>
+      )}
+      <div className="flex gap-2">
+        {visit && (
+          <button
+            onClick={() => { setEditing(false); setError(null) }}
+            className="flex-1 py-2.5 rounded-xl font-body font-semibold text-[13px] transition-all active:scale-[0.98]"
+            style={{ color: 'var(--bark-400)', border: '1.5px solid rgba(196,184,166,0.3)' }}
+          >
+            Cancelar
+          </button>
+        )}
+        <button
+          onClick={handleMark}
+          disabled={saving || !date}
+          className="flex-1 py-2.5 rounded-xl font-body font-semibold text-[13px] text-white transition-all active:scale-[0.98] disabled:opacity-50"
+          style={{ background: 'var(--moss-500)' }}
+        >
+          {saving ? 'Marcando...' : 'Marcar llegada'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -99,6 +99,14 @@ export default function Layout() {
   const firstName = (session?.user?.name || '').trim().split(/\s+/)[0]
   const greeting = getGreeting()
 
+  // El rol externo solo navega a Tareas; el resto del menú se oculta.
+  const isExterno = profile?.member_type === 'externo'
+  const visibleSections = isExterno
+    ? navSections
+        .map(s => ({ ...s, items: s.items.filter(i => i.to === '/tasks') }))
+        .filter(s => s.items.length > 0)
+    : navSections
+
   useEffect(() => {
     fetchHouseProfile().then(p => {
       setProfile(p)
@@ -370,7 +378,7 @@ export default function Layout() {
 
             {/* Nav sections */}
             <nav className="flex-1 overflow-y-auto py-3 px-3">
-              {navSections.map((section, idx) => (
+              {visibleSections.map((section, idx) => (
                 <div key={section.title} className={idx > 0 ? 'mt-5' : ''}>
                   <div
                     className="px-3 mb-1.5 font-body text-[10px] font-semibold uppercase"

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -75,6 +75,16 @@ export async function fetchTaskHistory(taskId, limit = 10) {
   return request(`/completions/${taskId}/history?limit=${limit}`)
 }
 
+// --- Visitas (rol externo) ---
+
+export async function fetchActiveVisit() {
+  return request('/visits/active')
+}
+
+export async function markVisit(visited_on) {
+  return request('/visits', { method: 'POST', body: JSON.stringify({ visited_on }) })
+}
+
 // --- Product images ---
 
 export async function uploadProductImage(file) {
@@ -246,6 +256,10 @@ export async function fetchSuperAdminStats() {
 
 export async function fetchHouseMembers() {
   return request('/houses/members')
+}
+
+export async function setMemberType(userId, member_type) {
+  return request(`/houses/members/${userId}/type`, { method: 'PATCH', body: JSON.stringify({ member_type }) })
 }
 
 export async function fetchHouseProfile() {

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import { fetchPendingTasks, completeTask, overdueLabel, frequencyLabel, urgencyBucket } from '../lib/tasks'
+import { fetchHouseProfile, fetchActiveVisit } from '../lib/api'
 import TaskCard from '../components/TaskCard'
 import ProgressRing from '../components/ProgressRing'
 import SearchInput from '../components/SearchInput'
+import ArrivalBanner from '../components/ArrivalBanner'
 
 export default function Home() {
   const [tasks, setTasks] = useState([])
@@ -10,6 +12,9 @@ export default function Home() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [query, setQuery] = useState('')
+  const [isExterno, setIsExterno] = useState(false)
+  const [visit, setVisit] = useState(null)
+  const [notice, setNotice] = useState(null)
 
   const loadTasks = useCallback(async () => {
     try {
@@ -34,9 +39,29 @@ export default function Home() {
 
   useEffect(() => { loadTasks() }, [loadTasks])
 
+  useEffect(() => {
+    let cancelled = false
+    fetchHouseProfile()
+      .then(p => {
+        if (cancelled) return
+        const externo = p?.member_type === 'externo'
+        setIsExterno(externo)
+        if (externo) return fetchActiveVisit().then(v => { if (!cancelled) setVisit(v) })
+      })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [])
+
   const [completed, setCompleted] = useState(0)
 
   async function handleComplete(taskId) {
+    // El externo debe marcar su llegada antes de registrar tareas (la fecha de la
+    // visita es la que heredan las completaciones).
+    if (isExterno && !visit) {
+      setNotice('Marca tu llegada antes de registrar tareas.')
+      window.scrollTo({ top: 0, behavior: 'smooth' })
+      return
+    }
     try {
       await completeTask(taskId)
       setCompleted(prev => prev + 1)
@@ -102,6 +127,24 @@ export default function Home() {
 
   return (
     <div className="fade-in">
+      {/* Marca de llegada para el rol externo */}
+      {isExterno && (
+        <ArrivalBanner
+          visit={visit}
+          onMarked={v => { setVisit(v); setNotice(null) }}
+        />
+      )}
+
+      {/* Aviso cuando falta marcar la llegada */}
+      {notice && (
+        <div
+          className="rounded-xl p-3 mb-5 font-body text-[13px] font-medium"
+          style={{ background: 'rgba(184,90,58,0.08)', border: '1px solid rgba(184,90,58,0.2)', color: 'var(--clay-500)' }}
+        >
+          {notice}
+        </div>
+      )}
+
       {/* Header with progress */}
       <div className="flex items-start justify-between mb-7">
         <div>

--- a/frontend/src/pages/HouseSettings.jsx
+++ b/frontend/src/pages/HouseSettings.jsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router-dom'
 import { authClient } from '../lib/auth'
 import { getActiveHouse, setActiveHouse, clearActiveHouse, AVATARS, COLORS } from '../lib/house'
-import { fetchHouseMembers, fetchHouseProfile, updateHouseProfile, fetchVapidKey, subscribePush, unsubscribePush, fetchPushStatus, deleteHouse, fetchInvitations, deleteInvitation, renewInvitation } from '../lib/api'
+import { fetchHouseMembers, fetchHouseProfile, updateHouseProfile, fetchVapidKey, subscribePush, unsubscribePush, fetchPushStatus, deleteHouse, fetchInvitations, deleteInvitation, renewInvitation, setMemberType } from '../lib/api'
 import { HOME_SCREENS, setStoredHomeScreen, DEFAULT_HOME_SCREEN } from '../lib/homeScreen'
 
 export default function HouseSettings() {
@@ -12,6 +12,8 @@ export default function HouseSettings() {
   const [members, setMembers] = useState([])
   const [myProfile, setMyProfile] = useState(null)
   const [myRole, setMyRole] = useState('member')
+  const [myMemberType, setMyMemberType] = useState('regular')
+  const [togglingTypeId, setTogglingTypeId] = useState(null)
   const [loading, setLoading] = useState(true)
   const [inviteEmail, setInviteEmail] = useState('')
   const [inviteRole, setInviteRole] = useState('member')
@@ -49,6 +51,7 @@ export default function HouseSettings() {
       const me = membersData.find(m => m.userId === session?.user?.id)
       if (me) {
         setMyRole(me.role)
+        setMyMemberType(me.member_type || 'regular')
         if (me.role === 'owner' || me.role === 'admin') {
           loadInvitations()
         }
@@ -207,6 +210,20 @@ export default function HouseSettings() {
     } else {
       setRemovingId(userId)
       setTimeout(() => setRemovingId(null), 3000)
+    }
+  }
+
+  async function handleToggleExterno(userId, currentType) {
+    const next = currentType === 'externo' ? 'regular' : 'externo'
+    setTogglingTypeId(userId)
+    try {
+      await setMemberType(userId, next)
+      setMembers(prev => prev.map(m => m.userId === userId ? { ...m, member_type: next } : m))
+      showToast(next === 'externo' ? 'Marcado como externo' : 'Marcado como regular')
+    } catch (err) {
+      showToast(err.message || 'Error al cambiar el tipo', 'error')
+    } finally {
+      setTogglingTypeId(null)
     }
   }
 
@@ -421,6 +438,7 @@ export default function HouseSettings() {
       </div>
 
       {/* Home screen preference */}
+      {myMemberType !== 'externo' && (
       <div className="mb-6">
         <h3 className="font-display text-lg mb-1" style={{ color: 'var(--bark-700)' }}>
           Pantalla de inicio
@@ -453,6 +471,7 @@ export default function HouseSettings() {
           })}
         </div>
       </div>
+      )}
 
       {/* Members */}
       <div className="mb-6">
@@ -487,6 +506,27 @@ export default function HouseSettings() {
               >
                 {roleLabel(m.role)}
               </span>
+              {isOwnerOrAdmin && m.userId !== session?.user?.id && m.role !== 'owner' ? (
+                <button
+                  onClick={() => handleToggleExterno(m.userId, m.member_type)}
+                  disabled={togglingTypeId === m.userId}
+                  className="px-2 py-1 rounded-lg text-[10px] font-body font-semibold flex-shrink-0 transition-all active:scale-95 disabled:opacity-50"
+                  style={m.member_type === 'externo'
+                    ? { background: 'rgba(184,90,58,0.12)', color: 'var(--clay-500)' }
+                    : { background: 'var(--surface-elevated)', color: 'var(--bark-400)', border: '1px solid rgba(196,184,166,0.3)' }}
+                >
+                  {togglingTypeId === m.userId ? '...' : (m.member_type === 'externo' ? 'Externo ✓' : 'Externo')}
+                </button>
+              ) : (
+                m.member_type === 'externo' && (
+                  <span
+                    className="px-2 py-0.5 rounded-full text-[10px] font-body font-semibold flex-shrink-0"
+                    style={{ background: 'rgba(184,90,58,0.12)', color: 'var(--clay-500)' }}
+                  >
+                    Externo
+                  </span>
+                )
+              )}
               {isOwnerOrAdmin && m.userId !== session?.user?.id && m.role !== 'owner' && (
                 <button
                   onClick={() => handleRemoveMember(m.userId)}

--- a/server/index.js
+++ b/server/index.js
@@ -161,7 +161,8 @@ app.get('/api/houses/members', requireAuth, requireHouse, async (req, res) => {
       SELECT m."userId", m.role, m."createdAt",
              u.name, u.email,
              COALESCE(p.avatar, '🧑') as avatar,
-             COALESCE(p.color, '#6a9960') as color
+             COALESCE(p.color, '#6a9960') as color,
+             COALESCE(p.member_type, 'regular') as member_type
       FROM "member" m
       JOIN "user" u ON m."userId" = u.id
       LEFT JOIN house_member_profiles p ON p.user_id = m."userId" AND p.organization_id = m."organizationId"
@@ -169,6 +170,35 @@ app.get('/api/houses/members', requireAuth, requireHouse, async (req, res) => {
       ORDER BY m."createdAt"
     `, [req.house.id])
     res.json(rows)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+const VALID_MEMBER_TYPES = ['regular', 'externo']
+
+// PATCH /api/houses/members/:userId/type - owner/admin marca a un miembro como externo (o regular)
+app.patch('/api/houses/members/:userId/type', requireAuth, requireHouse, requireRole('owner', 'admin'), async (req, res) => {
+  try {
+    const { userId } = req.params
+    const { member_type } = req.body
+    if (!VALID_MEMBER_TYPES.includes(member_type)) {
+      return res.status(400).json({ error: 'Tipo de miembro invalido' })
+    }
+    const { rows: target } = await pool.query(
+      'SELECT role FROM "member" WHERE "userId" = $1 AND "organizationId" = $2',
+      [userId, req.house.id]
+    )
+    if (target.length === 0) return res.status(404).json({ error: 'Miembro no encontrado' })
+    if (target[0].role === 'owner') return res.status(400).json({ error: 'No puedes cambiar el tipo del dueño' })
+
+    await pool.query(`
+      INSERT INTO house_member_profiles (user_id, organization_id, member_type)
+      VALUES ($1, $2, $3)
+      ON CONFLICT (user_id, organization_id)
+      DO UPDATE SET member_type = EXCLUDED.member_type
+    `, [userId, req.house.id, member_type])
+    res.json({ user_id: userId, member_type })
   } catch (err) {
     res.status(500).json({ error: err.message })
   }
@@ -184,10 +214,11 @@ app.get('/api/houses/profile', requireAuth, requireHouse, async (req, res) => {
       [req.user.id, req.house.id]
     )
     if (rows.length === 0) {
-      return res.json({ user_id: req.user.id, organization_id: req.house.id, avatar: '🧑', color: '#6a9960', home_screen: 'tasks' })
+      return res.json({ user_id: req.user.id, organization_id: req.house.id, avatar: '🧑', color: '#6a9960', home_screen: 'tasks', member_type: 'regular' })
     }
     const profile = rows[0]
     if (!profile.home_screen) profile.home_screen = 'tasks'
+    if (!profile.member_type) profile.member_type = 'regular'
     res.json(profile)
   } catch (err) {
     res.status(500).json({ error: err.message })
@@ -618,9 +649,30 @@ app.post('/api/completions', requireAuth, requireHouse, async (req, res) => {
     )
     if (taskCheck.length === 0) return res.status(404).json({ error: 'Tarea no encontrada' })
 
+    // El personal externo no fija la fecha: sus tareas heredan la fecha de la visita
+    // marcada (nunca posterior), para que los contadores no se corran al registrar tarde.
+    let completedAt = completed_at || new Date().toISOString()
+    if (req.house.memberType === 'externo') {
+      const { rows: visit } = await pool.query(`
+        SELECT to_char(visited_on, 'YYYY-MM-DD') AS d
+        FROM visits
+        WHERE organization_id = $1 AND user_id = $2
+        ORDER BY created_at DESC
+        LIMIT 1
+      `, [req.house.id, req.user.id])
+      if (visit.length === 0) {
+        return res.status(400).json({ error: 'Marca tu llegada antes de registrar tareas' })
+      }
+      // Mediodia UTC del dia de la visita: mantiene el mismo dia calendario en los
+      // contadores y, si la visita es hoy, se topa con el momento actual.
+      const visitTs = new Date(`${visit[0].d}T12:00:00.000Z`)
+      const now = new Date()
+      completedAt = (visitTs > now ? now : visitTs).toISOString()
+    }
+
     const { rows } = await pool.query(
       'INSERT INTO completions (task_id, completed_at, completed_by, user_id) VALUES ($1, $2, $3, $4) RETURNING *',
-      [task_id, completed_at || new Date().toISOString(), req.user.name || null, req.user.id]
+      [task_id, completedAt, req.user.name || null, req.user.id]
     )
 
     // Tareas efimeras de una sola vez: se desactivan automaticamente al cumplirse.
@@ -640,6 +692,51 @@ app.post('/api/completions', requireAuth, requireHouse, async (req, res) => {
       tag: 'task-completed',
     })
 
+    res.json(rows[0])
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// --- Visitas del personal externo ---
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+// GET /api/visits/active - ultima visita registrada por el usuario en esta casa
+app.get('/api/visits/active', requireAuth, requireHouse, async (req, res) => {
+  try {
+    const { rows } = await pool.query(`
+      SELECT id, to_char(visited_on, 'YYYY-MM-DD') AS visited_on, created_at
+      FROM visits
+      WHERE organization_id = $1 AND user_id = $2
+      ORDER BY created_at DESC
+      LIMIT 1
+    `, [req.house.id, req.user.id])
+    res.json(rows[0] || null)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// POST /api/visits - el externo marca su llegada (fecha de la visita, nunca futura)
+app.post('/api/visits', requireAuth, requireHouse, async (req, res) => {
+  try {
+    if (req.house.memberType !== 'externo') {
+      return res.status(403).json({ error: 'Solo el rol externo marca llegada' })
+    }
+    const { visited_on } = req.body
+    if (!visited_on || !DATE_RE.test(visited_on)) {
+      return res.status(400).json({ error: 'Fecha de visita invalida' })
+    }
+    const { rows: chk } = await pool.query('SELECT ($1::date > CURRENT_DATE) AS future', [visited_on])
+    if (chk[0].future) {
+      return res.status(400).json({ error: 'La fecha de la visita no puede ser futura' })
+    }
+    const { rows } = await pool.query(`
+      INSERT INTO visits (organization_id, user_id, visited_on)
+      VALUES ($1, $2, $3)
+      RETURNING id, to_char(visited_on, 'YYYY-MM-DD') AS visited_on, created_at
+    `, [req.house.id, req.user.id, visited_on])
     res.json(rows[0])
   } catch (err) {
     res.status(500).json({ error: err.message })
@@ -1391,6 +1488,9 @@ async function migrate() {
     // Pantalla de inicio personalizable por usuario en cada casa
     await addColumnIfMissing('house_member_profiles', 'home_screen', "TEXT NOT NULL DEFAULT 'tasks'")
 
+    // Rol externo (personal de aseo): flag a nivel de app sobre el perfil del miembro
+    await addColumnIfMissing('house_member_profiles', 'member_type', "TEXT NOT NULL DEFAULT 'regular'")
+
     // Archivado de compras + historial para recomendaciones (Fase 2)
     await addColumnIfMissing('shopping_items', 'purchased_at', 'TIMESTAMPTZ')
     await addColumnIfMissing('shopping_items', 'archived_at', 'TIMESTAMPTZ')
@@ -1410,6 +1510,18 @@ async function migrate() {
         UNIQUE(user_id, organization_id)
       )
     `)
+
+    // Visitas del personal externo (marca de llegada -> fecha que heredan sus tareas)
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS visits (
+        id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+        organization_id TEXT NOT NULL,
+        user_id         TEXT NOT NULL,
+        visited_on      DATE NOT NULL,
+        created_at      TIMESTAMPTZ DEFAULT NOW()
+      )
+    `)
+    await pool.query('CREATE INDEX IF NOT EXISTS idx_visits_org_user ON visits(organization_id, user_id, created_at DESC)')
 
     // Super admins table
     await pool.query(`

--- a/server/lib/middleware.js
+++ b/server/lib/middleware.js
@@ -45,12 +45,16 @@ export function createRequireHouse(pool) {
 
     try {
       const { rows } = await pool.query(
-        'SELECT * FROM "member" WHERE "userId" = $1 AND "organizationId" = $2',
+        `SELECT m.role, COALESCE(p.member_type, 'regular') AS member_type
+         FROM "member" m
+         LEFT JOIN house_member_profiles p
+           ON p.user_id = m."userId" AND p.organization_id = m."organizationId"
+         WHERE "userId" = $1 AND "organizationId" = $2`,
         [req.user.id, houseId]
       )
       if (rows.length === 0) return res.status(403).json({ error: 'No eres miembro de esta casa' })
 
-      req.house = { id: houseId, role: rows[0].role }
+      req.house = { id: houseId, role: rows[0].role, memberType: rows[0].member_type }
       next()
     } catch (err) {
       return res.status(500).json({ error: err.message })

--- a/server/lib/middleware.test.js
+++ b/server/lib/middleware.test.js
@@ -144,6 +144,16 @@ describe('createRequireHouse', () => {
     expect(next).toHaveBeenCalledOnce()
   })
 
+  it('expone member_type en req.house (rol externo)', async () => {
+    req.headers['x-house-id'] = 'house-1'
+    pool.query.mockResolvedValue({ rows: [{ role: 'member', member_type: 'externo' }] })
+
+    await createRequireHouse(pool)(req, res, next)
+
+    expect(req.house).toEqual({ id: 'house-1', role: 'member', memberType: 'externo' })
+    expect(next).toHaveBeenCalledOnce()
+  })
+
   it('filtra SIEMPRE por userId y organizationId (multi-tenant)', async () => {
     req.headers['x-house-id'] = 'house-42'
     pool.query.mockResolvedValue({ rows: [{ role: 'member' }] })


### PR DESCRIPTION
Nuevo tipo de miembro 'externo' (personal de aseo) como flag a nivel de app
en house_member_profiles. El externo marca su llegada (visita con fecha, nunca
futura) y las tareas que completa heredan esa fecha en el servidor, de modo que
registrar las tareas el dia despues no corre los contadores.

- Schema: columna member_type + tabla visits (init.sql + migracion)
- requireHouse expone req.house.memberType
- Endpoints: POST/GET visits, PATCH members/:id/type, completions usa la visita
- Frontend: ArrivalBanner, menu reducido para externo, toggle en Configuracion

https://claude.ai/code/session_01742dFjBEzvrCPNXTSibitQ