### PR TITLE
feat: cualquier miembro de la casa puede crear tareas

### DIFF
--- a/.claude/code-graph.json
+++ b/.claude/code-graph.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T00:15:06.321Z",
+  "generatedAt": "2026-08-21T03:18:44.231Z",
   "sources": [
     "server/index.js",
     "server/auth.js",
@@ -414,7 +414,7 @@
       ],
       "fks": [],
       "hasOrgId": true,
-      "source": "server/index.js:1562"
+      "source": "server/index.js:1564"
     }
   },
   "routes": [
@@ -422,7 +422,7 @@
       "file": "server/index.js",
       "method": "ALL",
       "path": "/api/auth/*",
-      "line": 79,
+      "line": 80,
       "middlewares": [],
       "queries": []
     },
@@ -430,13 +430,13 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/super-admin/check",
-      "line": 88,
+      "line": 89,
       "middlewares": [
         "requireAuth"
       ],
       "queries": [
         {
-          "line": 90,
+          "line": 91,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT id FROM super_admins WHERE user_id = $1",
@@ -452,14 +452,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/super-admin/stats",
-      "line": 101,
+      "line": 102,
       "middlewares": [
         "requireAuth",
         "requireSuperAdmin"
       ],
       "queries": [
         {
-          "line": 104,
+          "line": 105,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT COUNT(*) as count FROM \"user\"",
@@ -470,7 +470,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 105,
+          "line": 106,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT COUNT(*) as count FROM \"organization\"",
@@ -481,7 +481,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 106,
+          "line": 107,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT COUNT(*) as count FROM \"member\"",
@@ -492,7 +492,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 107,
+          "line": 108,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT COUNT(*) as count FROM tasks",
@@ -503,7 +503,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 108,
+          "line": 109,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT COUNT(*) as count FROM completions",
@@ -514,7 +514,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 109,
+          "line": 110,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT DATE(completed_at) as day, COUNT(*) as count\n        FROM completions\n        WHERE completed_at >= NOW() - INTERVAL '30 days'\n        GROUP BY DATE(completed_at)\n        ORDER BY day",
@@ -525,7 +525,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 116,
+          "line": 117,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT o.id, o.name, o.slug, COUNT(DISTINCT m.\"userId\") as member_count,\n               COUNT(DISTINCT t.id) as task_count,\n               COUNT(DISTINCT c.id) as completion_count,\n               MAX(c.completed_at) as last_activity\n        FROM \"organization\" o\n        LEFT JOIN \"member\" m ON m.\"organizationId\" = o.id\n        LEFT JOIN tasks t ON t.organization_id = o.id\n        LEFT JOIN completions c ON c.task_id = t.id\n        GROUP BY o.id, o.name, o.slug\n        ORDER BY last_activity DESC NULLS LAST",
@@ -544,14 +544,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/houses/members",
-      "line": 158,
+      "line": 159,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 160,
+          "line": 161,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT m.\"userId\", m.role, m.\"createdAt\",\n             u.name, u.email,\n             COALESCE(p.avatar, '🧑') as avatar,\n             COALESCE(p.color, '#6a9960') as color,\n             COALESCE(p.member_type, 'regular') as member_type\n      FROM \"member\" m\n      JOIN \"user\" u ON m.\"userId\" = u.id\n      LEFT JOIN house_member_profiles p ON p.user_id = m.\"userId\" AND p.organization_id = m.\"organizationId\"\n      WHERE m.\"organizationId\" = $1\n      ORDER BY m.\"createdAt\"",
@@ -569,7 +569,7 @@
       "file": "server/index.js",
       "method": "PATCH",
       "path": "/api/houses/members/:userId/type",
-      "line": 181,
+      "line": 182,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -577,7 +577,7 @@
       ],
       "queries": [
         {
-          "line": 188,
+          "line": 189,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT role FROM \"member\" WHERE \"userId\" = $1 AND \"organizationId\" = $2",
@@ -588,7 +588,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 195,
+          "line": 196,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO house_member_profiles (user_id, organization_id, member_type)\n      VALUES ($1, $2, $3)\n      ON CONFLICT (user_id, organization_id)\n      DO UPDATE SET member_type = EXCLUDED.member_type",
@@ -604,14 +604,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/houses/profile",
-      "line": 210,
+      "line": 211,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 212,
+          "line": 213,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT * FROM house_member_profiles WHERE user_id = $1 AND organization_id = $2",
@@ -627,14 +627,14 @@
       "file": "server/index.js",
       "method": "PUT",
       "path": "/api/houses/profile",
-      "line": 229,
+      "line": 230,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 235,
+          "line": 236,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT avatar, color, home_screen FROM house_member_profiles WHERE user_id = $1 AND organization_id = $2",
@@ -645,7 +645,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 243,
+          "line": 244,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO house_member_profiles (user_id, organization_id, avatar, color, home_screen)\n      VALUES ($1, $2, $3, $4, $5)\n      ON CONFLICT (user_id, organization_id)\n      DO UPDATE SET avatar = EXCLUDED.avatar, color = EXCLUDED.color, home_screen = EXCLUDED.home_screen\n      RETURNING *",
@@ -661,7 +661,7 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/invitations",
-      "line": 257,
+      "line": 258,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -669,7 +669,7 @@
       ],
       "queries": [
         {
-          "line": 259,
+          "line": 260,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT i.id, i.email, i.role, i.status, i.\"expiresAt\", i.\"inviterId\",\n             u.name as inviter_name, u.email as inviter_email\n      FROM \"invitation\" i\n      LEFT JOIN \"user\" u ON u.id = i.\"inviterId\"\n      WHERE i.\"organizationId\" = $1 AND i.status = 'pending'\n      ORDER BY i.\"expiresAt\" DESC",
@@ -686,7 +686,7 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/invitations/:id",
-      "line": 274,
+      "line": 275,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -694,7 +694,7 @@
       ],
       "queries": [
         {
-          "line": 276,
+          "line": 277,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM \"invitation\" WHERE id = $1 AND \"organizationId\" = $2 AND status = 'pending'",
@@ -710,7 +710,7 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/invitations/:id/renew",
-      "line": 290,
+      "line": 291,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -718,7 +718,7 @@
       ],
       "queries": [
         {
-          "line": 292,
+          "line": 293,
           "client": "pool",
           "dynamic": false,
           "sql": "UPDATE \"invitation\"\n       SET \"expiresAt\" = NOW() + INTERVAL '7 days'\n       WHERE id = $1 AND \"organizationId\" = $2 AND status = 'pending'\n       RETURNING id, email, role, status, \"expiresAt\"",
@@ -734,13 +734,13 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/houses/:id",
-      "line": 309,
+      "line": 310,
       "middlewares": [
         "requireAuth"
       ],
       "queries": [
         {
-          "line": 316,
+          "line": 317,
           "client": "client",
           "dynamic": false,
           "sql": "SELECT role FROM \"member\" WHERE \"userId\" = $1 AND \"organizationId\" = $2",
@@ -751,7 +751,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 327,
+          "line": 328,
           "client": "client",
           "dynamic": false,
           "sql": "BEGIN",
@@ -760,7 +760,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 329,
+          "line": 330,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM tasks WHERE organization_id = $1",
@@ -771,7 +771,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 330,
+          "line": 331,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM products WHERE organization_id = $1",
@@ -782,7 +782,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 331,
+          "line": 332,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM shopping_items WHERE organization_id = $1",
@@ -793,7 +793,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 332,
+          "line": 333,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM shopping_categories WHERE organization_id = $1",
@@ -804,7 +804,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 333,
+          "line": 334,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM house_member_profiles WHERE organization_id = $1",
@@ -815,7 +815,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 334,
+          "line": 335,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM push_subscriptions WHERE organization_id = $1",
@@ -826,7 +826,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 335,
+          "line": 336,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM plant_watering_history WHERE plant_id IN (SELECT id FROM plants WHERE organization_id = $1)",
@@ -838,7 +838,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 339,
+          "line": 340,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM plants WHERE organization_id = $1",
@@ -849,7 +849,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 341,
+          "line": 342,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM \"invitation\" WHERE \"organizationId\" = $1",
@@ -860,7 +860,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 342,
+          "line": 343,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM \"member\" WHERE \"organizationId\" = $1",
@@ -871,7 +871,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 343,
+          "line": 344,
           "client": "client",
           "dynamic": false,
           "sql": "DELETE FROM \"organization\" WHERE id = $1",
@@ -882,7 +882,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 344,
+          "line": 345,
           "client": "client",
           "dynamic": false,
           "sql": "COMMIT",
@@ -891,7 +891,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 348,
+          "line": 349,
           "client": "client",
           "dynamic": false,
           "sql": "ROLLBACK",
@@ -905,7 +905,7 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/houses/seed",
-      "line": 356,
+      "line": 357,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -913,7 +913,7 @@
       ],
       "queries": [
         {
-          "line": 363,
+          "line": 364,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT COUNT(*) as c FROM tasks WHERE organization_id = $1",
@@ -924,7 +924,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 399,
+          "line": 400,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO tasks (name, description, frequency_type, frequency_value, is_active, organization_id) VALUES ${values}",
@@ -935,7 +935,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 435,
+          "line": 436,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO tasks (name, description, frequency_type, frequency_value, is_active, organization_id) VALUES ${values}",
@@ -946,7 +946,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 491,
+          "line": 492,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO products (name, category, reminder_frequency_days, is_out_of_stock, organization_id) VALUES ${pValues}",
@@ -962,11 +962,11 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/health",
-      "line": 504,
+      "line": 505,
       "middlewares": [],
       "queries": [
         {
-          "line": 506,
+          "line": 507,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT 1",
@@ -980,7 +980,7 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/uploads",
-      "line": 515,
+      "line": 516,
       "middlewares": [
         "requireAuth",
         "upload.single('image')"
@@ -991,7 +991,7 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/uploads/:filename",
-      "line": 520,
+      "line": 521,
       "middlewares": [
         "requireAuth"
       ],
@@ -1001,14 +1001,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/tasks/pending",
-      "line": 532,
+      "line": 533,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 534,
+          "line": 535,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT t.*, c.last_completed_at\n      FROM tasks t\n      LEFT JOIN (\n        SELECT task_id, MAX(completed_at) AS last_completed_at\n        FROM completions\n        GROUP BY task_id\n      ) c ON t.id = c.task_id\n      WHERE t.is_active = true\n        AND t.organization_id = $1\n        AND (\n          c.last_completed_at IS NULL\n          OR (t.frequency_type <> 'once' AND NOW() >= c.last_completed_at + (t.frequency_value * INTERVAL '1 day'))\n          OR (t.last_reset_at IS NOT NULL AND t.last_reset_at > c.last_completed_at)\n        )\n      ORDER BY t.name",
@@ -1025,14 +1025,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/tasks",
-      "line": 558,
+      "line": 559,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 564,
+          "line": 565,
           "client": "pool",
           "dynamic": true,
           "sql": null,
@@ -1046,15 +1046,15 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/tasks",
-      "line": 572,
+      "line": 574,
       "middlewares": [
         "requireAuth",
         "requireHouse",
-        "requireRole('owner', 'admin')"
+        "denyExternalMembers"
       ],
       "queries": [
         {
-          "line": 575,
+          "line": 577,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO tasks (name, description, frequency_type, frequency_value, is_active, product_name, product_image, organization_id)\n       VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *",
@@ -1070,7 +1070,7 @@
       "file": "server/index.js",
       "method": "PATCH",
       "path": "/api/tasks/:id",
-      "line": 587,
+      "line": 589,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -1078,7 +1078,7 @@
       ],
       "queries": [
         {
-          "line": 597,
+          "line": 599,
           "client": "pool",
           "dynamic": true,
           "sql": null,
@@ -1092,7 +1092,7 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/tasks/:id",
-      "line": 606,
+      "line": 608,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -1100,7 +1100,7 @@
       ],
       "queries": [
         {
-          "line": 609,
+          "line": 611,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT product_image FROM tasks WHERE id = $1 AND organization_id = $2",
@@ -1111,7 +1111,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 616,
+          "line": 618,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM completions WHERE task_id = $1",
@@ -1122,7 +1122,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 617,
+          "line": 619,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM tasks WHERE id = $1 AND organization_id = $2",
@@ -1138,14 +1138,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/completions",
-      "line": 627,
+      "line": 629,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 629,
+          "line": 631,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT c.task_id, c.completed_at, c.completed_by, c.user_id\n      FROM completions c\n      JOIN tasks t ON c.task_id = t.id\n      WHERE t.organization_id = $1\n      ORDER BY c.completed_at DESC",
@@ -1162,14 +1162,14 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/completions",
-      "line": 643,
+      "line": 645,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 647,
+          "line": 649,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT id, name, frequency_type FROM tasks WHERE id = $1 AND organization_id = $2",
@@ -1180,7 +1180,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 656,
+          "line": 658,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT to_char(visited_on, 'YYYY-MM-DD') AS d\n        FROM visits\n        WHERE organization_id = $1 AND user_id = $2\n        ORDER BY created_at DESC\n        LIMIT 1",
@@ -1191,7 +1191,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 673,
+          "line": 675,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO completions (task_id, completed_at, completed_by, user_id) VALUES ($1, $2, $3, $4) RETURNING *",
@@ -1202,7 +1202,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 680,
+          "line": 682,
           "client": "pool",
           "dynamic": false,
           "sql": "UPDATE tasks SET is_active = false WHERE id = $1 AND organization_id = $2",
@@ -1218,14 +1218,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/visits/active",
-      "line": 706,
+      "line": 708,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 708,
+          "line": 710,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT id, to_char(visited_on, 'YYYY-MM-DD') AS visited_on, created_at\n      FROM visits\n      WHERE organization_id = $1 AND user_id = $2\n      ORDER BY created_at DESC\n      LIMIT 1",
@@ -1241,14 +1241,14 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/visits",
-      "line": 722,
+      "line": 724,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 731,
+          "line": 733,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT ($1::date > CURRENT_DATE) AS future",
@@ -1257,7 +1257,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 735,
+          "line": 737,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO visits (organization_id, user_id, visited_on)\n      VALUES ($1, $2, $3)\n      RETURNING id, to_char(visited_on, 'YYYY-MM-DD') AS visited_on, created_at",
@@ -1273,7 +1273,7 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/tasks/:id/reset",
-      "line": 748,
+      "line": 750,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -1281,7 +1281,7 @@
       ],
       "queries": [
         {
-          "line": 751,
+          "line": 753,
           "client": "pool",
           "dynamic": false,
           "sql": "UPDATE tasks SET last_reset_at = NOW() WHERE id = $1 AND organization_id = $2 RETURNING *",
@@ -1297,14 +1297,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/completions/:taskId/history",
-      "line": 763,
+      "line": 765,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 766,
+          "line": 768,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT c.* FROM completions c\n      JOIN tasks t ON c.task_id = t.id\n      WHERE c.task_id = $1 AND t.organization_id = $2\n      ORDER BY c.completed_at DESC LIMIT $3",
@@ -1321,14 +1321,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/products",
-      "line": 781,
+      "line": 783,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 797,
+          "line": 799,
           "client": "pool",
           "dynamic": true,
           "sql": null,
@@ -1342,14 +1342,14 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/products",
-      "line": 805,
+      "line": 807,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 809,
+          "line": 811,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO products (name, category, reminder_frequency_days, is_out_of_stock, units, organization_id)\n       VALUES ($1, $2, $3, $4, $5, $6) RETURNING *",
@@ -1365,14 +1365,14 @@
       "file": "server/index.js",
       "method": "PATCH",
       "path": "/api/products/:id",
-      "line": 821,
+      "line": 823,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 837,
+          "line": 839,
           "client": "pool",
           "dynamic": true,
           "sql": null,
@@ -1386,14 +1386,14 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/products/:id/purchase",
-      "line": 846,
+      "line": 848,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 849,
+          "line": 851,
           "client": "pool",
           "dynamic": false,
           "sql": "UPDATE products\n       SET last_purchased_at = NOW(), is_out_of_stock = false, last_out_of_stock_at = NULL\n       WHERE id = $1 AND organization_id = $2 RETURNING *",
@@ -1409,14 +1409,14 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/products/:id",
-      "line": 863,
+      "line": 865,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 866,
+          "line": 868,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM products WHERE id = $1 AND organization_id = $2",
@@ -1432,14 +1432,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/shopping-categories",
-      "line": 876,
+      "line": 878,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 878,
+          "line": 880,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT * FROM shopping_categories WHERE organization_id = $1 ORDER BY sort_order, name",
@@ -1455,7 +1455,7 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/shopping-categories",
-      "line": 889,
+      "line": 891,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -1463,7 +1463,7 @@
       ],
       "queries": [
         {
-          "line": 894,
+          "line": 896,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT COALESCE(MAX(sort_order), -1) + 1 as next_order FROM shopping_categories WHERE organization_id = $1",
@@ -1474,7 +1474,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 898,
+          "line": 900,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO shopping_categories (name, emoji, sort_order, organization_id) VALUES ($1, $2, $3, $4) RETURNING *",
@@ -1490,7 +1490,7 @@
       "file": "server/index.js",
       "method": "PATCH",
       "path": "/api/shopping-categories/:id",
-      "line": 909,
+      "line": 911,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -1498,7 +1498,7 @@
       ],
       "queries": [
         {
-          "line": 919,
+          "line": 921,
           "client": "pool",
           "dynamic": true,
           "sql": null,
@@ -1512,7 +1512,7 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/shopping-categories/:id",
-      "line": 928,
+      "line": 930,
       "middlewares": [
         "requireAuth",
         "requireHouse",
@@ -1520,7 +1520,7 @@
       ],
       "queries": [
         {
-          "line": 931,
+          "line": 933,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM shopping_categories WHERE id = $1 AND organization_id = $2",
@@ -1536,14 +1536,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/shopping-items",
-      "line": 941,
+      "line": 943,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 944,
+          "line": 946,
           "client": "pool",
           "dynamic": false,
           "sql": "UPDATE shopping_items\n       SET archived_at = NOW()\n       WHERE organization_id = $1\n         AND is_purchased = true\n         AND archived_at IS NULL\n         AND purchased_at IS NOT NULL\n         AND purchased_at < NOW() - ($2 || ' days')::INTERVAL",
@@ -1554,7 +1554,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 955,
+          "line": 957,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT si.*, sc.name as category_name, sc.emoji as category_emoji\n      FROM shopping_items si\n      LEFT JOIN shopping_categories sc ON si.category_id = sc.id\n      WHERE si.organization_id = $1 AND si.archived_at IS NULL\n      ORDER BY si.is_purchased, sc.sort_order NULLS LAST, si.created_at DESC",
@@ -1571,14 +1571,14 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/shopping-items",
-      "line": 969,
+      "line": 971,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 973,
+          "line": 975,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO shopping_items (name, note, added_by, category_id, organization_id) VALUES ($1, $2, $3, $4, $5) RETURNING *",
@@ -1594,14 +1594,14 @@
       "file": "server/index.js",
       "method": "PATCH",
       "path": "/api/shopping-items/:id",
-      "line": 984,
+      "line": 986,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1006,
+          "line": 1008,
           "client": "pool",
           "dynamic": true,
           "sql": null,
@@ -1615,14 +1615,14 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/shopping-items/clear-purchased",
-      "line": 1016,
+      "line": 1018,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1019,
+          "line": 1021,
           "client": "pool",
           "dynamic": false,
           "sql": "UPDATE shopping_items\n       SET purchased_at = COALESCE(purchased_at, NOW()),\n           archived_at = NOW()\n       WHERE is_purchased = true\n         AND archived_at IS NULL\n         AND organization_id = $1",
@@ -1638,14 +1638,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/shopping-items/history",
-      "line": 1036,
+      "line": 1038,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1039,
+          "line": 1041,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT si.*, sc.name as category_name, sc.emoji as category_emoji\n      FROM shopping_items si\n      LEFT JOIN shopping_categories sc ON si.category_id = sc.id\n      WHERE si.organization_id = $1 AND si.archived_at IS NOT NULL\n      ORDER BY si.archived_at DESC, si.purchased_at DESC NULLS LAST\n      LIMIT $2",
@@ -1662,14 +1662,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/shopping-items/recommendations",
-      "line": 1055,
+      "line": 1057,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1057,
+          "line": 1059,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT si.id, si.name, si.category_id, si.purchased_at,\n             sc.name as category_name, sc.emoji as category_emoji\n      FROM shopping_items si\n      LEFT JOIN shopping_categories sc ON si.category_id = sc.id\n      WHERE si.organization_id = $1\n        AND si.archived_at IS NOT NULL\n        AND si.purchased_at IS NOT NULL\n      ORDER BY si.purchased_at DESC",
@@ -1681,7 +1681,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1068,
+          "line": 1070,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT name FROM shopping_items\n       WHERE organization_id = $1 AND archived_at IS NULL",
@@ -1697,14 +1697,14 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/shopping-items/:id",
-      "line": 1082,
+      "line": 1084,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1085,
+          "line": 1087,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM shopping_items WHERE id = $1 AND organization_id = $2",
@@ -1720,14 +1720,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/plants",
-      "line": 1095,
+      "line": 1097,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1097,
+          "line": 1099,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT * FROM plants WHERE organization_id = $1 ORDER BY name",
@@ -1743,14 +1743,14 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/plants",
-      "line": 1108,
+      "line": 1110,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1113,
+          "line": 1115,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO plants (name, notes, watering_frequency_days, organization_id)\n       VALUES ($1, $2, $3, $4) RETURNING *",
@@ -1766,14 +1766,14 @@
       "file": "server/index.js",
       "method": "PATCH",
       "path": "/api/plants/:id",
-      "line": 1125,
+      "line": 1127,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1132,
+          "line": 1134,
           "client": "pool",
           "dynamic": false,
           "sql": "UPDATE plants SET name = $3, notes = $4, watering_frequency_days = $5\n       WHERE id = $1 AND organization_id = $2 RETURNING *",
@@ -1789,14 +1789,14 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/plants/:id",
-      "line": 1145,
+      "line": 1147,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1148,
+          "line": 1150,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM plants WHERE id = $1 AND organization_id = $2",
@@ -1812,14 +1812,14 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/plants/:id/water",
-      "line": 1160,
+      "line": 1162,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1164,
+          "line": 1166,
           "client": "client",
           "dynamic": false,
           "sql": "SELECT id, name FROM plants WHERE id = $1 AND organization_id = $2",
@@ -1830,7 +1830,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1170,
+          "line": 1172,
           "client": "client",
           "dynamic": false,
           "sql": "BEGIN",
@@ -1839,7 +1839,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1171,
+          "line": 1173,
           "client": "client",
           "dynamic": false,
           "sql": "INSERT INTO plant_watering_history (plant_id, watered_at, watered_by, user_id) VALUES ($1, NOW(), $2, $3)",
@@ -1850,7 +1850,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1175,
+          "line": 1177,
           "client": "client",
           "dynamic": false,
           "sql": "UPDATE plants SET last_watered_at = NOW() WHERE id = $1 AND organization_id = $2 RETURNING *",
@@ -1861,7 +1861,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1179,
+          "line": 1181,
           "client": "client",
           "dynamic": false,
           "sql": "COMMIT",
@@ -1870,7 +1870,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1189,
+          "line": 1191,
           "client": "client",
           "dynamic": false,
           "sql": "ROLLBACK",
@@ -1884,14 +1884,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/plants/:id/history",
-      "line": 1197,
+      "line": 1199,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1200,
+          "line": 1202,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT h.* FROM plant_watering_history h\n      JOIN plants p ON h.plant_id = p.id\n      WHERE h.plant_id = $1 AND p.organization_id = $2\n      ORDER BY h.watered_at DESC LIMIT $3",
@@ -1908,14 +1908,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/stats/participation",
-      "line": 1215,
+      "line": 1217,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1226,
+          "line": 1228,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT\n        c.user_id,\n        COALESCE(c.completed_by, 'Desconocido') as name,\n        COALESCE(p.avatar, '🧑') as avatar,\n        COALESCE(p.color, '#6a9960') as color,\n        COUNT(*) as completions\n      FROM completions c\n      JOIN tasks t ON c.task_id = t.id\n      LEFT JOIN house_member_profiles p ON p.user_id = c.user_id AND p.organization_id = t.organization_id\n      WHERE t.organization_id = $1 ${dateFilter}\n      GROUP BY c.user_id, c.completed_by, p.avatar, p.color\n      ORDER BY completions DESC",
@@ -1928,7 +1928,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1246,
+          "line": 1248,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT\n        DATE(c.completed_at) as date,\n        COUNT(*) as count\n      FROM completions c\n      JOIN tasks t ON c.task_id = t.id\n      WHERE t.organization_id = $1\n        AND c.completed_at >= NOW() - INTERVAL '${chartDays} days'\n      GROUP BY DATE(c.completed_at)\n      ORDER BY date",
@@ -1940,7 +1940,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1259,
+          "line": 1261,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT\n        t.name,\n        COUNT(*) as completions\n      FROM completions c\n      JOIN tasks t ON c.task_id = t.id\n      WHERE t.organization_id = $1 ${dateFilter}\n      GROUP BY t.name\n      ORDER BY completions DESC\n      LIMIT 5",
@@ -1957,7 +1957,7 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/push/vapid-key",
-      "line": 1301,
+      "line": 1303,
       "middlewares": [],
       "queries": []
     },
@@ -1965,14 +1965,14 @@
       "file": "server/index.js",
       "method": "POST",
       "path": "/api/push/subscribe",
-      "line": 1308,
+      "line": 1310,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1315,
+          "line": 1317,
           "client": "pool",
           "dynamic": false,
           "sql": "INSERT INTO push_subscriptions (user_id, organization_id, endpoint, keys_p256dh, keys_auth)\n      VALUES ($1, $2, $3, $4, $5)\n      ON CONFLICT (endpoint) DO UPDATE SET\n        user_id = EXCLUDED.user_id,\n        organization_id = EXCLUDED.organization_id,\n        keys_p256dh = EXCLUDED.keys_p256dh,\n        keys_auth = EXCLUDED.keys_auth,\n        updated_at = NOW()",
@@ -1988,13 +1988,13 @@
       "file": "server/index.js",
       "method": "DELETE",
       "path": "/api/push/subscribe",
-      "line": 1333,
+      "line": 1335,
       "middlewares": [
         "requireAuth"
       ],
       "queries": [
         {
-          "line": 1337,
+          "line": 1339,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM push_subscriptions WHERE endpoint = $1 AND user_id = $2",
@@ -2010,14 +2010,14 @@
       "file": "server/index.js",
       "method": "GET",
       "path": "/api/push/status",
-      "line": 1345,
+      "line": 1347,
       "middlewares": [
         "requireAuth",
         "requireHouse"
       ],
       "queries": [
         {
-          "line": 1347,
+          "line": 1349,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT id FROM push_subscriptions WHERE user_id = $1 AND organization_id = $2 LIMIT 1",
@@ -2034,10 +2034,10 @@
     {
       "name": "sendPushToHouse",
       "file": "server/index.js",
-      "line": 1358,
+      "line": 1360,
       "queries": [
         {
-          "line": 1362,
+          "line": 1364,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT endpoint, keys_p256dh, keys_auth FROM push_subscriptions WHERE organization_id = $1",
@@ -2048,7 +2048,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1376,
+          "line": 1378,
           "client": "pool",
           "dynamic": false,
           "sql": "DELETE FROM push_subscriptions WHERE endpoint = $1",
@@ -2063,10 +2063,10 @@
     {
       "name": "migrate",
       "file": "server/index.js",
-      "line": 1388,
+      "line": 1390,
       "queries": [
         {
-          "line": 1391,
+          "line": 1393,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS tasks (\n        id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        name        TEXT NOT NULL,\n        description TEXT,\n        frequency_type  TEXT NOT NULL CHECK (frequency_type IN ('daily', 'weekly', 'biweekly', 'monthly')),\n        frequency_value INTEGER NOT NULL DEFAULT 1,\n        is_active   BOOLEAN NOT NULL DEFAULT true,\n        product_name  TEXT,\n        product_image TEXT,\n        organization_id TEXT,\n        created_at  TIMESTAMPTZ DEFAULT NOW()\n      )",
@@ -2075,7 +2075,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1406,
+          "line": 1408,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS completions (\n        id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        task_id     UUID NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,\n        completed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n        completed_by TEXT,\n        user_id TEXT\n      )",
@@ -2084,7 +2084,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1415,
+          "line": 1417,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_completions_task_id ON completions(task_id)",
@@ -2093,7 +2093,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1416,
+          "line": 1418,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_completions_completed_at ON completions(completed_at DESC)",
@@ -2102,7 +2102,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1418,
+          "line": 1420,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS products (\n        id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        name            TEXT NOT NULL,\n        category        TEXT NOT NULL DEFAULT 'general',\n        is_out_of_stock BOOLEAN NOT NULL DEFAULT false,\n        reminder_frequency_days INTEGER NOT NULL DEFAULT 30,\n        last_purchased_at TIMESTAMPTZ,\n        organization_id TEXT,\n        created_at      TIMESTAMPTZ DEFAULT NOW()\n      )",
@@ -2111,7 +2111,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1430,
+          "line": 1432,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_products_category ON products(category)",
@@ -2120,7 +2120,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1431,
+          "line": 1433,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_products_out_of_stock ON products(is_out_of_stock)",
@@ -2129,7 +2129,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1433,
+          "line": 1435,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS shopping_categories (\n        id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        name            TEXT NOT NULL,\n        emoji           TEXT NOT NULL DEFAULT '📦',\n        sort_order      INTEGER NOT NULL DEFAULT 0,\n        organization_id TEXT NOT NULL,\n        created_at      TIMESTAMPTZ DEFAULT NOW()\n      )",
@@ -2138,7 +2138,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1443,
+          "line": 1445,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_categories_org ON shopping_categories(organization_id)",
@@ -2147,7 +2147,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1445,
+          "line": 1447,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS shopping_items (\n        id           UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        name         TEXT NOT NULL,\n        note         TEXT,\n        added_by     TEXT,\n        is_purchased BOOLEAN NOT NULL DEFAULT false,\n        category_id  UUID REFERENCES shopping_categories(id) ON DELETE SET NULL,\n        organization_id TEXT,\n        created_at   TIMESTAMPTZ DEFAULT NOW()\n      )",
@@ -2156,7 +2156,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1457,
+          "line": 1459,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_purchased ON shopping_items(is_purchased)",
@@ -2165,7 +2165,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1458,
+          "line": 1460,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_category ON shopping_items(category_id)",
@@ -2174,7 +2174,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1480,
+          "line": 1482,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_tasks_org ON tasks(organization_id)",
@@ -2183,7 +2183,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1481,
+          "line": 1483,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_products_org ON products(organization_id)",
@@ -2192,7 +2192,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1482,
+          "line": 1484,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_org ON shopping_items(organization_id)",
@@ -2201,7 +2201,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1486,
+          "line": 1488,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_category ON shopping_items(category_id)",
@@ -2210,7 +2210,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1497,
+          "line": 1499,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_archived ON shopping_items(archived_at)",
@@ -2219,7 +2219,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1498,
+          "line": 1500,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_shopping_items_purchased_at ON shopping_items(purchased_at DESC)",
@@ -2228,7 +2228,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1501,
+          "line": 1503,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS house_member_profiles (\n        id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        user_id         TEXT NOT NULL,\n        organization_id TEXT NOT NULL,\n        avatar          TEXT NOT NULL DEFAULT '🧑',\n        color           TEXT NOT NULL DEFAULT '#6a9960',\n        home_screen     TEXT NOT NULL DEFAULT 'tasks',\n        created_at      TIMESTAMPTZ DEFAULT NOW(),\n        UNIQUE(user_id, organization_id)\n      )",
@@ -2237,7 +2237,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1515,
+          "line": 1517,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS visits (\n        id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        organization_id TEXT NOT NULL,\n        user_id         TEXT NOT NULL,\n        visited_on      DATE NOT NULL,\n        created_at      TIMESTAMPTZ DEFAULT NOW()\n      )",
@@ -2246,7 +2246,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1524,
+          "line": 1526,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_visits_org_user ON visits(organization_id, user_id, created_at DESC)",
@@ -2255,7 +2255,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1527,
+          "line": 1529,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS super_admins (\n        id         UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        user_id    TEXT NOT NULL UNIQUE,\n        created_at TIMESTAMPTZ DEFAULT NOW()\n      )",
@@ -2264,7 +2264,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1536,
+          "line": 1538,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS plants (\n        id                       UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        name                     TEXT NOT NULL,\n        notes                    TEXT,\n        watering_frequency_days  INTEGER NOT NULL DEFAULT 7,\n        last_watered_at          TIMESTAMPTZ,\n        organization_id          TEXT NOT NULL,\n        created_at               TIMESTAMPTZ DEFAULT NOW()\n      )",
@@ -2273,7 +2273,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1547,
+          "line": 1549,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_plants_org ON plants(organization_id)",
@@ -2282,7 +2282,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1549,
+          "line": 1551,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS plant_watering_history (\n        id          UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        plant_id    UUID NOT NULL REFERENCES plants(id) ON DELETE CASCADE,\n        watered_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n        watered_by  TEXT,\n        user_id     TEXT\n      )",
@@ -2291,7 +2291,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1558,
+          "line": 1560,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_plant_watering_plant_id ON plant_watering_history(plant_id)",
@@ -2300,7 +2300,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1559,
+          "line": 1561,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_plant_watering_at ON plant_watering_history(watered_at DESC)",
@@ -2309,7 +2309,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1562,
+          "line": 1564,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE TABLE IF NOT EXISTS push_subscriptions (\n        id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,\n        user_id         TEXT NOT NULL,\n        organization_id TEXT NOT NULL,\n        endpoint        TEXT NOT NULL UNIQUE,\n        keys_p256dh     TEXT NOT NULL,\n        keys_auth       TEXT NOT NULL,\n        created_at      TIMESTAMPTZ DEFAULT NOW(),\n        updated_at      TIMESTAMPTZ DEFAULT NOW()\n      )",
@@ -2318,7 +2318,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1574,
+          "line": 1576,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_push_subs_org ON push_subscriptions(organization_id)",
@@ -2327,7 +2327,7 @@
           "filtersByOrgId": true
         },
         {
-          "line": 1575,
+          "line": 1577,
           "client": "pool",
           "dynamic": false,
           "sql": "CREATE INDEX IF NOT EXISTS idx_push_subs_user ON push_subscriptions(user_id)",
@@ -2340,10 +2340,10 @@
     {
       "name": "addColumnIfMissing",
       "file": "server/index.js",
-      "line": 1583,
+      "line": 1585,
       "queries": [
         {
-          "line": 1584,
+          "line": 1586,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT column_name FROM information_schema.columns\n    WHERE table_name = $1 AND column_name = $2",
@@ -2352,7 +2352,7 @@
           "filtersByOrgId": false
         },
         {
-          "line": 1589,
+          "line": 1591,
           "client": "pool",
           "dynamic": false,
           "sql": "ALTER TABLE ${table} ADD COLUMN ${column} ${type}",
@@ -2365,10 +2365,10 @@
     {
       "name": "requireHouse",
       "file": "server/lib/middleware.js",
-      "line": 42,
+      "line": 54,
       "queries": [
         {
-          "line": 47,
+          "line": 59,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT m.role, COALESCE(p.member_type, 'regular') AS member_type\n         FROM \"member\" m\n         LEFT JOIN house_member_profiles p\n           ON p.user_id = m.\"userId\" AND p.organization_id = m.\"organizationId\"\n         WHERE \"userId\" = $1 AND \"organizationId\" = $2",
@@ -2384,10 +2384,10 @@
     {
       "name": "requireSuperAdmin",
       "file": "server/lib/middleware.js",
-      "line": 70,
+      "line": 82,
       "queries": [
         {
-          "line": 72,
+          "line": 84,
           "client": "pool",
           "dynamic": false,
           "sql": "SELECT id FROM super_admins WHERE user_id = $1",
@@ -2460,7 +2460,7 @@
           "method": "GET",
           "path": "/api/super-admin/stats",
           "file": "server/index.js",
-          "line": 107,
+          "line": 108,
           "op": "SELECT",
           "filtersByOrgId": false
         },
@@ -2469,7 +2469,7 @@
           "method": "GET",
           "path": "/api/super-admin/stats",
           "file": "server/index.js",
-          "line": 116,
+          "line": 117,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2478,7 +2478,7 @@
           "method": "POST",
           "path": "/api/houses/seed",
           "file": "server/index.js",
-          "line": 363,
+          "line": 364,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2487,7 +2487,7 @@
           "method": "GET",
           "path": "/api/tasks/pending",
           "file": "server/index.js",
-          "line": 534,
+          "line": 535,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2496,7 +2496,7 @@
           "method": "DELETE",
           "path": "/api/tasks/:id",
           "file": "server/index.js",
-          "line": 609,
+          "line": 611,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2505,7 +2505,7 @@
           "method": "GET",
           "path": "/api/completions",
           "file": "server/index.js",
-          "line": 629,
+          "line": 631,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2514,7 +2514,7 @@
           "method": "POST",
           "path": "/api/completions",
           "file": "server/index.js",
-          "line": 647,
+          "line": 649,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2523,7 +2523,7 @@
           "method": "GET",
           "path": "/api/completions/:taskId/history",
           "file": "server/index.js",
-          "line": 766,
+          "line": 768,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2532,7 +2532,7 @@
           "method": "GET",
           "path": "/api/stats/participation",
           "file": "server/index.js",
-          "line": 1226,
+          "line": 1228,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2541,7 +2541,7 @@
           "method": "GET",
           "path": "/api/stats/participation",
           "file": "server/index.js",
-          "line": 1246,
+          "line": 1248,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2550,7 +2550,7 @@
           "method": "GET",
           "path": "/api/stats/participation",
           "file": "server/index.js",
-          "line": 1259,
+          "line": 1261,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -2561,7 +2561,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 329,
+          "line": 330,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -2570,7 +2570,7 @@
           "method": "POST",
           "path": "/api/houses/seed",
           "file": "server/index.js",
-          "line": 399,
+          "line": 400,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -2579,7 +2579,7 @@
           "method": "POST",
           "path": "/api/houses/seed",
           "file": "server/index.js",
-          "line": 435,
+          "line": 436,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -2588,7 +2588,7 @@
           "method": "POST",
           "path": "/api/tasks",
           "file": "server/index.js",
-          "line": 575,
+          "line": 577,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -2597,7 +2597,7 @@
           "method": "DELETE",
           "path": "/api/tasks/:id",
           "file": "server/index.js",
-          "line": 617,
+          "line": 619,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -2606,7 +2606,7 @@
           "method": "POST",
           "path": "/api/completions",
           "file": "server/index.js",
-          "line": 680,
+          "line": 682,
           "op": "UPDATE",
           "filtersByOrgId": true
         },
@@ -2615,7 +2615,7 @@
           "method": "POST",
           "path": "/api/tasks/:id/reset",
           "file": "server/index.js",
-          "line": 751,
+          "line": 753,
           "op": "UPDATE",
           "filtersByOrgId": true
         }
@@ -2662,15 +2662,6 @@
           "method": "GET",
           "path": "/api/super-admin/stats",
           "file": "server/index.js",
-          "line": 108,
-          "op": "SELECT",
-          "filtersByOrgId": false
-        },
-        {
-          "kind": "route",
-          "method": "GET",
-          "path": "/api/super-admin/stats",
-          "file": "server/index.js",
           "line": 109,
           "op": "SELECT",
           "filtersByOrgId": false
@@ -2680,7 +2671,16 @@
           "method": "GET",
           "path": "/api/super-admin/stats",
           "file": "server/index.js",
-          "line": 116,
+          "line": 110,
+          "op": "SELECT",
+          "filtersByOrgId": false
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/super-admin/stats",
+          "file": "server/index.js",
+          "line": 117,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2689,7 +2689,7 @@
           "method": "GET",
           "path": "/api/tasks/pending",
           "file": "server/index.js",
-          "line": 534,
+          "line": 535,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2698,7 +2698,7 @@
           "method": "GET",
           "path": "/api/completions",
           "file": "server/index.js",
-          "line": 629,
+          "line": 631,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2707,7 +2707,7 @@
           "method": "GET",
           "path": "/api/completions/:taskId/history",
           "file": "server/index.js",
-          "line": 766,
+          "line": 768,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2716,7 +2716,7 @@
           "method": "GET",
           "path": "/api/stats/participation",
           "file": "server/index.js",
-          "line": 1226,
+          "line": 1228,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2725,7 +2725,7 @@
           "method": "GET",
           "path": "/api/stats/participation",
           "file": "server/index.js",
-          "line": 1246,
+          "line": 1248,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2734,7 +2734,7 @@
           "method": "GET",
           "path": "/api/stats/participation",
           "file": "server/index.js",
-          "line": 1259,
+          "line": 1261,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -2745,7 +2745,7 @@
           "method": "DELETE",
           "path": "/api/tasks/:id",
           "file": "server/index.js",
-          "line": 616,
+          "line": 618,
           "op": "DELETE",
           "filtersByOrgId": false
         },
@@ -2754,7 +2754,7 @@
           "method": "POST",
           "path": "/api/completions",
           "file": "server/index.js",
-          "line": 673,
+          "line": 675,
           "op": "INSERT",
           "filtersByOrgId": false
         }
@@ -2816,7 +2816,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 330,
+          "line": 331,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -2825,7 +2825,7 @@
           "method": "POST",
           "path": "/api/houses/seed",
           "file": "server/index.js",
-          "line": 491,
+          "line": 492,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -2834,7 +2834,7 @@
           "method": "POST",
           "path": "/api/products",
           "file": "server/index.js",
-          "line": 809,
+          "line": 811,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -2843,7 +2843,7 @@
           "method": "POST",
           "path": "/api/products/:id/purchase",
           "file": "server/index.js",
-          "line": 849,
+          "line": 851,
           "op": "UPDATE",
           "filtersByOrgId": true
         },
@@ -2852,7 +2852,7 @@
           "method": "DELETE",
           "path": "/api/products/:id",
           "file": "server/index.js",
-          "line": 866,
+          "line": 868,
           "op": "DELETE",
           "filtersByOrgId": true
         }
@@ -2897,7 +2897,7 @@
           "method": "GET",
           "path": "/api/shopping-categories",
           "file": "server/index.js",
-          "line": 878,
+          "line": 880,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2906,7 +2906,7 @@
           "method": "POST",
           "path": "/api/shopping-categories",
           "file": "server/index.js",
-          "line": 894,
+          "line": 896,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2915,7 +2915,7 @@
           "method": "GET",
           "path": "/api/shopping-items",
           "file": "server/index.js",
-          "line": 955,
+          "line": 957,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2924,7 +2924,7 @@
           "method": "GET",
           "path": "/api/shopping-items/history",
           "file": "server/index.js",
-          "line": 1039,
+          "line": 1041,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -2933,7 +2933,7 @@
           "method": "GET",
           "path": "/api/shopping-items/recommendations",
           "file": "server/index.js",
-          "line": 1057,
+          "line": 1059,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -2944,7 +2944,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 332,
+          "line": 333,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -2953,7 +2953,7 @@
           "method": "POST",
           "path": "/api/shopping-categories",
           "file": "server/index.js",
-          "line": 898,
+          "line": 900,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -2962,7 +2962,7 @@
           "method": "DELETE",
           "path": "/api/shopping-categories/:id",
           "file": "server/index.js",
-          "line": 931,
+          "line": 933,
           "op": "DELETE",
           "filtersByOrgId": true
         }
@@ -3029,7 +3029,7 @@
           "method": "GET",
           "path": "/api/shopping-items",
           "file": "server/index.js",
-          "line": 955,
+          "line": 957,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -3038,7 +3038,7 @@
           "method": "GET",
           "path": "/api/shopping-items/history",
           "file": "server/index.js",
-          "line": 1039,
+          "line": 1041,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -3047,7 +3047,7 @@
           "method": "GET",
           "path": "/api/shopping-items/recommendations",
           "file": "server/index.js",
-          "line": 1057,
+          "line": 1059,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -3056,7 +3056,7 @@
           "method": "GET",
           "path": "/api/shopping-items/recommendations",
           "file": "server/index.js",
-          "line": 1068,
+          "line": 1070,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -3067,7 +3067,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 331,
+          "line": 332,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -3076,7 +3076,7 @@
           "method": "GET",
           "path": "/api/shopping-items",
           "file": "server/index.js",
-          "line": 944,
+          "line": 946,
           "op": "UPDATE",
           "filtersByOrgId": true
         },
@@ -3085,7 +3085,7 @@
           "method": "POST",
           "path": "/api/shopping-items",
           "file": "server/index.js",
-          "line": 973,
+          "line": 975,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -3094,7 +3094,7 @@
           "method": "DELETE",
           "path": "/api/shopping-items/clear-purchased",
           "file": "server/index.js",
-          "line": 1019,
+          "line": 1021,
           "op": "UPDATE",
           "filtersByOrgId": true
         },
@@ -3103,7 +3103,7 @@
           "method": "DELETE",
           "path": "/api/shopping-items/:id",
           "file": "server/index.js",
-          "line": 1085,
+          "line": 1087,
           "op": "DELETE",
           "filtersByOrgId": true
         }
@@ -3156,7 +3156,7 @@
           "method": "GET",
           "path": "/api/houses/members",
           "file": "server/index.js",
-          "line": 160,
+          "line": 161,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -3165,7 +3165,7 @@
           "method": "GET",
           "path": "/api/houses/profile",
           "file": "server/index.js",
-          "line": 212,
+          "line": 213,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -3174,7 +3174,7 @@
           "method": "PUT",
           "path": "/api/houses/profile",
           "file": "server/index.js",
-          "line": 235,
+          "line": 236,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -3183,7 +3183,7 @@
           "method": "GET",
           "path": "/api/stats/participation",
           "file": "server/index.js",
-          "line": 1226,
+          "line": 1228,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -3191,7 +3191,7 @@
           "kind": "helper",
           "helper": "requireHouse",
           "file": "server/lib/middleware.js",
-          "line": 47,
+          "line": 59,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -3202,7 +3202,7 @@
           "method": "PATCH",
           "path": "/api/houses/members/:userId/type",
           "file": "server/index.js",
-          "line": 195,
+          "line": 196,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -3211,7 +3211,7 @@
           "method": "PUT",
           "path": "/api/houses/profile",
           "file": "server/index.js",
-          "line": 243,
+          "line": 244,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -3220,7 +3220,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 333,
+          "line": 334,
           "op": "DELETE",
           "filtersByOrgId": true
         }
@@ -3261,7 +3261,7 @@
           "method": "POST",
           "path": "/api/completions",
           "file": "server/index.js",
-          "line": 656,
+          "line": 658,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -3270,7 +3270,7 @@
           "method": "GET",
           "path": "/api/visits/active",
           "file": "server/index.js",
-          "line": 708,
+          "line": 710,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -3281,7 +3281,7 @@
           "method": "POST",
           "path": "/api/visits",
           "file": "server/index.js",
-          "line": 735,
+          "line": 737,
           "op": "INSERT",
           "filtersByOrgId": true
         }
@@ -3314,7 +3314,7 @@
           "method": "GET",
           "path": "/api/super-admin/check",
           "file": "server/index.js",
-          "line": 90,
+          "line": 91,
           "op": "SELECT",
           "filtersByOrgId": false
         },
@@ -3322,7 +3322,7 @@
           "kind": "helper",
           "helper": "requireSuperAdmin",
           "file": "server/lib/middleware.js",
-          "line": 72,
+          "line": 84,
           "op": "SELECT",
           "filtersByOrgId": false
         }
@@ -3372,7 +3372,7 @@
           "method": "GET",
           "path": "/api/plants",
           "file": "server/index.js",
-          "line": 1097,
+          "line": 1099,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -3381,7 +3381,7 @@
           "method": "POST",
           "path": "/api/plants/:id/water",
           "file": "server/index.js",
-          "line": 1164,
+          "line": 1166,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -3390,7 +3390,7 @@
           "method": "GET",
           "path": "/api/plants/:id/history",
           "file": "server/index.js",
-          "line": 1200,
+          "line": 1202,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -3401,7 +3401,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 335,
+          "line": 336,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -3410,7 +3410,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 339,
+          "line": 340,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -3419,7 +3419,7 @@
           "method": "POST",
           "path": "/api/plants",
           "file": "server/index.js",
-          "line": 1113,
+          "line": 1115,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -3428,7 +3428,7 @@
           "method": "PATCH",
           "path": "/api/plants/:id",
           "file": "server/index.js",
-          "line": 1132,
+          "line": 1134,
           "op": "UPDATE",
           "filtersByOrgId": true
         },
@@ -3437,7 +3437,7 @@
           "method": "DELETE",
           "path": "/api/plants/:id",
           "file": "server/index.js",
-          "line": 1148,
+          "line": 1150,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -3446,7 +3446,7 @@
           "method": "POST",
           "path": "/api/plants/:id/water",
           "file": "server/index.js",
-          "line": 1175,
+          "line": 1177,
           "op": "UPDATE",
           "filtersByOrgId": true
         }
@@ -3493,7 +3493,7 @@
           "method": "GET",
           "path": "/api/plants/:id/history",
           "file": "server/index.js",
-          "line": 1200,
+          "line": 1202,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -3504,7 +3504,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 335,
+          "line": 336,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -3513,7 +3513,7 @@
           "method": "POST",
           "path": "/api/plants/:id/water",
           "file": "server/index.js",
-          "line": 1171,
+          "line": 1173,
           "op": "INSERT",
           "filtersByOrgId": false
         }
@@ -3558,7 +3558,7 @@
         ],
         "fks": [],
         "hasOrgId": true,
-        "source": "server/index.js:1562"
+        "source": "server/index.js:1564"
       },
       "readers": [
         {
@@ -3566,7 +3566,7 @@
           "method": "GET",
           "path": "/api/push/status",
           "file": "server/index.js",
-          "line": 1347,
+          "line": 1349,
           "op": "SELECT",
           "filtersByOrgId": true
         },
@@ -3574,7 +3574,7 @@
           "kind": "helper",
           "helper": "sendPushToHouse",
           "file": "server/index.js",
-          "line": 1362,
+          "line": 1364,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -3585,7 +3585,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 334,
+          "line": 335,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -3594,7 +3594,7 @@
           "method": "POST",
           "path": "/api/push/subscribe",
           "file": "server/index.js",
-          "line": 1315,
+          "line": 1317,
           "op": "INSERT",
           "filtersByOrgId": true
         },
@@ -3603,7 +3603,7 @@
           "method": "DELETE",
           "path": "/api/push/subscribe",
           "file": "server/index.js",
-          "line": 1337,
+          "line": 1339,
           "op": "DELETE",
           "filtersByOrgId": false
         },
@@ -3611,47 +3611,13 @@
           "kind": "helper",
           "helper": "sendPushToHouse",
           "file": "server/index.js",
-          "line": 1376,
+          "line": 1378,
           "op": "DELETE",
           "filtersByOrgId": false
         }
       ]
     },
     "user": {
-      "defined": false,
-      "schema": null,
-      "readers": [
-        {
-          "kind": "route",
-          "method": "GET",
-          "path": "/api/super-admin/stats",
-          "file": "server/index.js",
-          "line": 104,
-          "op": "SELECT",
-          "filtersByOrgId": false
-        },
-        {
-          "kind": "route",
-          "method": "GET",
-          "path": "/api/houses/members",
-          "file": "server/index.js",
-          "line": 160,
-          "op": "SELECT",
-          "filtersByOrgId": true
-        },
-        {
-          "kind": "route",
-          "method": "GET",
-          "path": "/api/invitations",
-          "file": "server/index.js",
-          "line": 259,
-          "op": "SELECT",
-          "filtersByOrgId": true
-        }
-      ],
-      "writers": []
-    },
-    "organization": {
       "defined": false,
       "schema": null,
       "readers": [
@@ -3667,26 +3633,25 @@
         {
           "kind": "route",
           "method": "GET",
-          "path": "/api/super-admin/stats",
+          "path": "/api/houses/members",
           "file": "server/index.js",
-          "line": 116,
+          "line": 161,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/invitations",
+          "file": "server/index.js",
+          "line": 260,
           "op": "SELECT",
           "filtersByOrgId": true
         }
       ],
-      "writers": [
-        {
-          "kind": "route",
-          "method": "DELETE",
-          "path": "/api/houses/:id",
-          "file": "server/index.js",
-          "line": 343,
-          "op": "DELETE",
-          "filtersByOrgId": false
-        }
-      ]
+      "writers": []
     },
-    "member": {
+    "organization": {
       "defined": false,
       "schema": null,
       "readers": [
@@ -3704,42 +3669,7 @@
           "method": "GET",
           "path": "/api/super-admin/stats",
           "file": "server/index.js",
-          "line": 116,
-          "op": "SELECT",
-          "filtersByOrgId": true
-        },
-        {
-          "kind": "route",
-          "method": "GET",
-          "path": "/api/houses/members",
-          "file": "server/index.js",
-          "line": 160,
-          "op": "SELECT",
-          "filtersByOrgId": true
-        },
-        {
-          "kind": "route",
-          "method": "PATCH",
-          "path": "/api/houses/members/:userId/type",
-          "file": "server/index.js",
-          "line": 188,
-          "op": "SELECT",
-          "filtersByOrgId": true
-        },
-        {
-          "kind": "route",
-          "method": "DELETE",
-          "path": "/api/houses/:id",
-          "file": "server/index.js",
-          "line": 316,
-          "op": "SELECT",
-          "filtersByOrgId": true
-        },
-        {
-          "kind": "helper",
-          "helper": "requireHouse",
-          "file": "server/lib/middleware.js",
-          "line": 47,
+          "line": 117,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -3750,7 +3680,77 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 342,
+          "line": 344,
+          "op": "DELETE",
+          "filtersByOrgId": false
+        }
+      ]
+    },
+    "member": {
+      "defined": false,
+      "schema": null,
+      "readers": [
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/super-admin/stats",
+          "file": "server/index.js",
+          "line": 107,
+          "op": "SELECT",
+          "filtersByOrgId": false
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/super-admin/stats",
+          "file": "server/index.js",
+          "line": 117,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "GET",
+          "path": "/api/houses/members",
+          "file": "server/index.js",
+          "line": 161,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "PATCH",
+          "path": "/api/houses/members/:userId/type",
+          "file": "server/index.js",
+          "line": 189,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/houses/:id",
+          "file": "server/index.js",
+          "line": 317,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        },
+        {
+          "kind": "helper",
+          "helper": "requireHouse",
+          "file": "server/lib/middleware.js",
+          "line": 59,
+          "op": "SELECT",
+          "filtersByOrgId": true
+        }
+      ],
+      "writers": [
+        {
+          "kind": "route",
+          "method": "DELETE",
+          "path": "/api/houses/:id",
+          "file": "server/index.js",
+          "line": 343,
           "op": "DELETE",
           "filtersByOrgId": true
         }
@@ -3765,7 +3765,7 @@
           "method": "GET",
           "path": "/api/invitations",
           "file": "server/index.js",
-          "line": 259,
+          "line": 260,
           "op": "SELECT",
           "filtersByOrgId": true
         }
@@ -3776,7 +3776,7 @@
           "method": "DELETE",
           "path": "/api/invitations/:id",
           "file": "server/index.js",
-          "line": 276,
+          "line": 277,
           "op": "DELETE",
           "filtersByOrgId": true
         },
@@ -3785,7 +3785,7 @@
           "method": "POST",
           "path": "/api/invitations/:id/renew",
           "file": "server/index.js",
-          "line": 292,
+          "line": 293,
           "op": "UPDATE",
           "filtersByOrgId": true
         },
@@ -3794,7 +3794,7 @@
           "method": "DELETE",
           "path": "/api/houses/:id",
           "file": "server/index.js",
-          "line": 341,
+          "line": 342,
           "op": "DELETE",
           "filtersByOrgId": true
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,19 @@
 
 ---
 
+## [Fase 1] — Retención y Engagement
+
+### 2026-08-21 — Cualquier miembro puede crear tareas
+- **Visión** — la propuesta de valor para familias es "saber quién hace qué y distribuir el trabajo". Que solo el dueño/admin pudiera dar de alta tareas convertía a los demás en ejecutores: veían el botón "Nueva" y recibían un 403. Ahora cualquier integrante de la casa suma pendientes cuando los detecta, sin pedirle permiso a nadie.
+- **Backend** — `POST /api/tasks` deja de exigir `requireRole('owner','admin')` y pasa a `denyExternalMembers`: entra cualquier miembro de la casa (owner, admin o member) salvo el personal externo, que sigue limitado a marcar llegada y completar tareas. `PATCH`, `DELETE` y `POST /api/tasks/:id/reset` **no cambian**: editar, borrar y resetear siguen siendo de dueño/admin.
+- **Nuevo middleware** — `denyExternalMembers` en `server/lib/middleware.js`, síncrono y puro como `requireRole`, apoyado en `req.house.memberType` que ya resolvía `requireHouse`. Responde 403 también si falta `req.house` (fail-closed).
+- **Frontend** — `Admin.jsx` deriva el rol propio de `fetchHouseMembers()` + la sesión (mismo patrón de `HouseSettings`) y expone `canManage`. Para un miembro regular el botón "Nueva" y el historial quedan visibles, mientras que resetear/editar/eliminar se ocultan y el checkbox de activa/inactiva queda deshabilitado: se elimina el bug de UI de botones que sólo devolvían 403.
+- **Tests** — backend 75/75 (4 casos nuevos de `denyExternalMembers`), frontend 166/166 (nuevo `pages/__tests__/Admin.test.jsx` con los tres roles), build de Vite verde (434 kB). Code graph regenerado.
+- **Pendiente sugerido** — un miembro que crea una tarea todavía no puede corregirla; el siguiente paso natural sería `created_by` en `tasks` para permitir editar/borrar lo propio.
+- Archivos: `server/index.js`, `server/lib/middleware.js`, `server/lib/middleware.test.js`, `frontend/src/pages/Admin.jsx`, `frontend/src/pages/__tests__/Admin.test.jsx`.
+
+---
+
 ## [Fase 3] — Monetización
 
 ### 2026-06-11 — Rol "externo": marca de llegada + fecha heredada por las tareas

--- a/docs/CODE_GRAPH.md
+++ b/docs/CODE_GRAPH.md
@@ -1,6 +1,6 @@
 # Code Graph — Casa Limpia
 
-_Generado automaticamente por `scripts/codegraph.js` el 2026-06-11T00:15:06.321Z._
+_Generado automaticamente por `scripts/codegraph.js` el 2026-08-21T03:18:44.231Z._
 
 **No editar a mano.** Regenerar con `npm run codegraph` despues de cambios en `server/` o `db/init.sql`.
 
@@ -20,346 +20,346 @@ _Generado automaticamente por `scripts/codegraph.js` el 2026-06-11T00:15:06.321Z
 
 Queries que tocan tablas con `organization_id` pero no lo filtran:
 
-- `GET /api/super-admin/stats` (server/index.js:107) — SELECT `tasks`
-- `DELETE /api/push/subscribe` (server/index.js:1337) — DELETE `push_subscriptions`
+- `GET /api/super-admin/stats` (server/index.js:108) — SELECT `tasks`
+- `DELETE /api/push/subscribe` (server/index.js:1339) — DELETE `push_subscriptions`
 
 ## API → Handler → SQL
 
 ### /api/auth
 
-**`ALL /api/auth/*`** — server/index.js:79
+**`ALL /api/auth/*`** — server/index.js:80
 
 - _Sin queries directas._
 
 ### /api/completions
 
-**`GET /api/completions`** — server/index.js:627 _[requireAuth, requireHouse]_
+**`GET /api/completions`** — server/index.js:629 _[requireAuth, requireHouse]_
 
-- [OK] L629 SELECT → `completions, tasks`
+- [OK] L631 SELECT → `completions, tasks`
 
-**`POST /api/completions`** — server/index.js:643 _[requireAuth, requireHouse]_
+**`POST /api/completions`** — server/index.js:645 _[requireAuth, requireHouse]_
 
-- [OK] L647 SELECT → `tasks`
-- [OK] L656 SELECT → `visits`
--      L673 INSERT → `completions`
-- [OK] L680 UPDATE → `tasks`
+- [OK] L649 SELECT → `tasks`
+- [OK] L658 SELECT → `visits`
+-      L675 INSERT → `completions`
+- [OK] L682 UPDATE → `tasks`
 
-**`GET /api/completions/:taskId/history`** — server/index.js:763 _[requireAuth, requireHouse]_
+**`GET /api/completions/:taskId/history`** — server/index.js:765 _[requireAuth, requireHouse]_
 
-- [OK] L766 SELECT → `completions, tasks`
+- [OK] L768 SELECT → `completions, tasks`
 
 ### /api/health
 
-**`GET /api/health`** — server/index.js:504
+**`GET /api/health`** — server/index.js:505
 
--      L506 SELECT
+-      L507 SELECT
 
 ### /api/houses
 
-**`GET /api/houses/members`** — server/index.js:158 _[requireAuth, requireHouse]_
+**`GET /api/houses/members`** — server/index.js:159 _[requireAuth, requireHouse]_
 
-- [OK] L160 SELECT → `member, user, house_member_profiles`
+- [OK] L161 SELECT → `member, user, house_member_profiles`
 
-**`PATCH /api/houses/members/:userId/type`** — server/index.js:181 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`PATCH /api/houses/members/:userId/type`** — server/index.js:182 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
--      L188 SELECT → `member`
-- [OK] L195 INSERT → `house_member_profiles`
+-      L189 SELECT → `member`
+- [OK] L196 INSERT → `house_member_profiles`
 
-**`GET /api/houses/profile`** — server/index.js:210 _[requireAuth, requireHouse]_
+**`GET /api/houses/profile`** — server/index.js:211 _[requireAuth, requireHouse]_
 
-- [OK] L212 SELECT → `house_member_profiles`
+- [OK] L213 SELECT → `house_member_profiles`
 
-**`PUT /api/houses/profile`** — server/index.js:229 _[requireAuth, requireHouse]_
+**`PUT /api/houses/profile`** — server/index.js:230 _[requireAuth, requireHouse]_
 
-- [OK] L235 SELECT → `house_member_profiles`
-- [OK] L243 INSERT → `house_member_profiles`
+- [OK] L236 SELECT → `house_member_profiles`
+- [OK] L244 INSERT → `house_member_profiles`
 
-**`DELETE /api/houses/:id`** — server/index.js:309 _[requireAuth]_
+**`DELETE /api/houses/:id`** — server/index.js:310 _[requireAuth]_
 
--      L316 SELECT → `member`
--      L327 BEGIN
-- [OK] L329 DELETE → `tasks`
-- [OK] L330 DELETE → `products`
-- [OK] L331 DELETE → `shopping_items`
-- [OK] L332 DELETE → `shopping_categories`
-- [OK] L333 DELETE → `house_member_profiles`
-- [OK] L334 DELETE → `push_subscriptions`
-- [OK] L335 DELETE → `plant_watering_history, plants`
-- [OK] L339 DELETE → `plants`
--      L341 DELETE → `invitation`
--      L342 DELETE → `member`
--      L343 DELETE → `organization`
--      L344 COMMIT
--      L348 ROLLBACK
+-      L317 SELECT → `member`
+-      L328 BEGIN
+- [OK] L330 DELETE → `tasks`
+- [OK] L331 DELETE → `products`
+- [OK] L332 DELETE → `shopping_items`
+- [OK] L333 DELETE → `shopping_categories`
+- [OK] L334 DELETE → `house_member_profiles`
+- [OK] L335 DELETE → `push_subscriptions`
+- [OK] L336 DELETE → `plant_watering_history, plants`
+- [OK] L340 DELETE → `plants`
+-      L342 DELETE → `invitation`
+-      L343 DELETE → `member`
+-      L344 DELETE → `organization`
+-      L345 COMMIT
+-      L349 ROLLBACK
 
-**`POST /api/houses/seed`** — server/index.js:356 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`POST /api/houses/seed`** — server/index.js:357 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
-- [OK] L363 SELECT → `tasks`
-- [OK] L399 INSERT → `tasks`
-- [OK] L435 INSERT → `tasks`
-- [OK] L491 INSERT → `products`
+- [OK] L364 SELECT → `tasks`
+- [OK] L400 INSERT → `tasks`
+- [OK] L436 INSERT → `tasks`
+- [OK] L492 INSERT → `products`
 
 ### /api/invitations
 
-**`GET /api/invitations`** — server/index.js:257 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`GET /api/invitations`** — server/index.js:258 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
--      L259 SELECT → `invitation, user`
+-      L260 SELECT → `invitation, user`
 
-**`DELETE /api/invitations/:id`** — server/index.js:274 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`DELETE /api/invitations/:id`** — server/index.js:275 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
--      L276 DELETE → `invitation`
+-      L277 DELETE → `invitation`
 
-**`POST /api/invitations/:id/renew`** — server/index.js:290 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`POST /api/invitations/:id/renew`** — server/index.js:291 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
--      L292 UPDATE → `invitation`
+-      L293 UPDATE → `invitation`
 
 ### /api/plants
 
-**`GET /api/plants`** — server/index.js:1095 _[requireAuth, requireHouse]_
+**`GET /api/plants`** — server/index.js:1097 _[requireAuth, requireHouse]_
 
-- [OK] L1097 SELECT → `plants`
+- [OK] L1099 SELECT → `plants`
 
-**`POST /api/plants`** — server/index.js:1108 _[requireAuth, requireHouse]_
+**`POST /api/plants`** — server/index.js:1110 _[requireAuth, requireHouse]_
 
-- [OK] L1113 INSERT → `plants`
+- [OK] L1115 INSERT → `plants`
 
-**`PATCH /api/plants/:id`** — server/index.js:1125 _[requireAuth, requireHouse]_
+**`PATCH /api/plants/:id`** — server/index.js:1127 _[requireAuth, requireHouse]_
 
-- [OK] L1132 UPDATE → `plants`
+- [OK] L1134 UPDATE → `plants`
 
-**`DELETE /api/plants/:id`** — server/index.js:1145 _[requireAuth, requireHouse]_
+**`DELETE /api/plants/:id`** — server/index.js:1147 _[requireAuth, requireHouse]_
 
-- [OK] L1148 DELETE → `plants`
+- [OK] L1150 DELETE → `plants`
 
-**`POST /api/plants/:id/water`** — server/index.js:1160 _[requireAuth, requireHouse]_
+**`POST /api/plants/:id/water`** — server/index.js:1162 _[requireAuth, requireHouse]_
 
-- [OK] L1164 SELECT → `plants`
--      L1170 BEGIN
--      L1171 INSERT → `plant_watering_history`
-- [OK] L1175 UPDATE → `plants`
--      L1179 COMMIT
--      L1189 ROLLBACK
+- [OK] L1166 SELECT → `plants`
+-      L1172 BEGIN
+-      L1173 INSERT → `plant_watering_history`
+- [OK] L1177 UPDATE → `plants`
+-      L1181 COMMIT
+-      L1191 ROLLBACK
 
-**`GET /api/plants/:id/history`** — server/index.js:1197 _[requireAuth, requireHouse]_
+**`GET /api/plants/:id/history`** — server/index.js:1199 _[requireAuth, requireHouse]_
 
-- [OK] L1200 SELECT → `plant_watering_history, plants`
+- [OK] L1202 SELECT → `plant_watering_history, plants`
 
 ### /api/products
 
-**`GET /api/products`** — server/index.js:781 _[requireAuth, requireHouse]_
+**`GET /api/products`** — server/index.js:783 _[requireAuth, requireHouse]_
 
-- L797 _dynamic SQL (`pool.query(variable)`)_
+- L799 _dynamic SQL (`pool.query(variable)`)_
 
-**`POST /api/products`** — server/index.js:805 _[requireAuth, requireHouse]_
+**`POST /api/products`** — server/index.js:807 _[requireAuth, requireHouse]_
 
-- [OK] L809 INSERT → `products`
+- [OK] L811 INSERT → `products`
 
-**`PATCH /api/products/:id`** — server/index.js:821 _[requireAuth, requireHouse]_
+**`PATCH /api/products/:id`** — server/index.js:823 _[requireAuth, requireHouse]_
 
-- L837 _dynamic SQL (`pool.query(variable)`)_
+- L839 _dynamic SQL (`pool.query(variable)`)_
 
-**`POST /api/products/:id/purchase`** — server/index.js:846 _[requireAuth, requireHouse]_
+**`POST /api/products/:id/purchase`** — server/index.js:848 _[requireAuth, requireHouse]_
 
-- [OK] L849 UPDATE → `products`
+- [OK] L851 UPDATE → `products`
 
-**`DELETE /api/products/:id`** — server/index.js:863 _[requireAuth, requireHouse]_
+**`DELETE /api/products/:id`** — server/index.js:865 _[requireAuth, requireHouse]_
 
-- [OK] L866 DELETE → `products`
+- [OK] L868 DELETE → `products`
 
 ### /api/push
 
-**`GET /api/push/vapid-key`** — server/index.js:1301
+**`GET /api/push/vapid-key`** — server/index.js:1303
 
 - _Sin queries directas._
 
-**`POST /api/push/subscribe`** — server/index.js:1308 _[requireAuth, requireHouse]_
+**`POST /api/push/subscribe`** — server/index.js:1310 _[requireAuth, requireHouse]_
 
-- [OK] L1315 INSERT → `push_subscriptions`
+- [OK] L1317 INSERT → `push_subscriptions`
 
-**`DELETE /api/push/subscribe`** — server/index.js:1333 _[requireAuth]_
+**`DELETE /api/push/subscribe`** — server/index.js:1335 _[requireAuth]_
 
-- [!!] L1337 DELETE → `push_subscriptions`
+- [!!] L1339 DELETE → `push_subscriptions`
 
-**`GET /api/push/status`** — server/index.js:1345 _[requireAuth, requireHouse]_
+**`GET /api/push/status`** — server/index.js:1347 _[requireAuth, requireHouse]_
 
-- [OK] L1347 SELECT → `push_subscriptions`
+- [OK] L1349 SELECT → `push_subscriptions`
 
 ### /api/shopping-categories
 
-**`GET /api/shopping-categories`** — server/index.js:876 _[requireAuth, requireHouse]_
+**`GET /api/shopping-categories`** — server/index.js:878 _[requireAuth, requireHouse]_
 
-- [OK] L878 SELECT → `shopping_categories`
+- [OK] L880 SELECT → `shopping_categories`
 
-**`POST /api/shopping-categories`** — server/index.js:889 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`POST /api/shopping-categories`** — server/index.js:891 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
-- [OK] L894 SELECT → `shopping_categories`
-- [OK] L898 INSERT → `shopping_categories`
+- [OK] L896 SELECT → `shopping_categories`
+- [OK] L900 INSERT → `shopping_categories`
 
-**`PATCH /api/shopping-categories/:id`** — server/index.js:909 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`PATCH /api/shopping-categories/:id`** — server/index.js:911 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
-- L919 _dynamic SQL (`pool.query(variable)`)_
+- L921 _dynamic SQL (`pool.query(variable)`)_
 
-**`DELETE /api/shopping-categories/:id`** — server/index.js:928 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`DELETE /api/shopping-categories/:id`** — server/index.js:930 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
-- [OK] L931 DELETE → `shopping_categories`
+- [OK] L933 DELETE → `shopping_categories`
 
 ### /api/shopping-items
 
-**`GET /api/shopping-items`** — server/index.js:941 _[requireAuth, requireHouse]_
+**`GET /api/shopping-items`** — server/index.js:943 _[requireAuth, requireHouse]_
 
-- [OK] L944 UPDATE → `shopping_items`
-- [OK] L955 SELECT → `shopping_items, shopping_categories`
+- [OK] L946 UPDATE → `shopping_items`
+- [OK] L957 SELECT → `shopping_items, shopping_categories`
 
-**`POST /api/shopping-items`** — server/index.js:969 _[requireAuth, requireHouse]_
+**`POST /api/shopping-items`** — server/index.js:971 _[requireAuth, requireHouse]_
 
-- [OK] L973 INSERT → `shopping_items`
+- [OK] L975 INSERT → `shopping_items`
 
-**`PATCH /api/shopping-items/:id`** — server/index.js:984 _[requireAuth, requireHouse]_
+**`PATCH /api/shopping-items/:id`** — server/index.js:986 _[requireAuth, requireHouse]_
 
-- L1006 _dynamic SQL (`pool.query(variable)`)_
+- L1008 _dynamic SQL (`pool.query(variable)`)_
 
-**`DELETE /api/shopping-items/clear-purchased`** — server/index.js:1016 _[requireAuth, requireHouse]_
+**`DELETE /api/shopping-items/clear-purchased`** — server/index.js:1018 _[requireAuth, requireHouse]_
 
-- [OK] L1019 UPDATE → `shopping_items`
+- [OK] L1021 UPDATE → `shopping_items`
 
-**`GET /api/shopping-items/history`** — server/index.js:1036 _[requireAuth, requireHouse]_
+**`GET /api/shopping-items/history`** — server/index.js:1038 _[requireAuth, requireHouse]_
 
-- [OK] L1039 SELECT → `shopping_items, shopping_categories`
+- [OK] L1041 SELECT → `shopping_items, shopping_categories`
 
-**`GET /api/shopping-items/recommendations`** — server/index.js:1055 _[requireAuth, requireHouse]_
+**`GET /api/shopping-items/recommendations`** — server/index.js:1057 _[requireAuth, requireHouse]_
 
-- [OK] L1057 SELECT → `shopping_items, shopping_categories`
-- [OK] L1068 SELECT → `shopping_items`
+- [OK] L1059 SELECT → `shopping_items, shopping_categories`
+- [OK] L1070 SELECT → `shopping_items`
 
-**`DELETE /api/shopping-items/:id`** — server/index.js:1082 _[requireAuth, requireHouse]_
+**`DELETE /api/shopping-items/:id`** — server/index.js:1084 _[requireAuth, requireHouse]_
 
-- [OK] L1085 DELETE → `shopping_items`
+- [OK] L1087 DELETE → `shopping_items`
 
 ### /api/stats
 
-**`GET /api/stats/participation`** — server/index.js:1215 _[requireAuth, requireHouse]_
+**`GET /api/stats/participation`** — server/index.js:1217 _[requireAuth, requireHouse]_
 
-- [OK] L1226 SELECT → `completions, tasks, house_member_profiles`
-- [OK] L1246 SELECT → `completions, tasks`
-- [OK] L1259 SELECT → `completions, tasks`
+- [OK] L1228 SELECT → `completions, tasks, house_member_profiles`
+- [OK] L1248 SELECT → `completions, tasks`
+- [OK] L1261 SELECT → `completions, tasks`
 
 ### /api/super-admin
 
-**`GET /api/super-admin/check`** — server/index.js:88 _[requireAuth]_
+**`GET /api/super-admin/check`** — server/index.js:89 _[requireAuth]_
 
--      L90 SELECT → `super_admins`
+-      L91 SELECT → `super_admins`
 
-**`GET /api/super-admin/stats`** — server/index.js:101 _[requireAuth, requireSuperAdmin]_
+**`GET /api/super-admin/stats`** — server/index.js:102 _[requireAuth, requireSuperAdmin]_
 
--      L104 SELECT → `user`
--      L105 SELECT → `organization`
--      L106 SELECT → `member`
-- [!!] L107 SELECT → `tasks`
--      L108 SELECT → `completions`
+-      L105 SELECT → `user`
+-      L106 SELECT → `organization`
+-      L107 SELECT → `member`
+- [!!] L108 SELECT → `tasks`
 -      L109 SELECT → `completions`
-- [OK] L116 SELECT → `organization, member, tasks, completions`
+-      L110 SELECT → `completions`
+- [OK] L117 SELECT → `organization, member, tasks, completions`
 
 ### /api/tasks
 
-**`GET /api/tasks/pending`** — server/index.js:532 _[requireAuth, requireHouse]_
+**`GET /api/tasks/pending`** — server/index.js:533 _[requireAuth, requireHouse]_
 
-- [OK] L534 SELECT → `tasks, completions`
+- [OK] L535 SELECT → `tasks, completions`
 
-**`GET /api/tasks`** — server/index.js:558 _[requireAuth, requireHouse]_
+**`GET /api/tasks`** — server/index.js:559 _[requireAuth, requireHouse]_
 
-- L564 _dynamic SQL (`pool.query(variable)`)_
+- L565 _dynamic SQL (`pool.query(variable)`)_
 
-**`POST /api/tasks`** — server/index.js:572 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`POST /api/tasks`** — server/index.js:574 _[requireAuth, requireHouse, denyExternalMembers]_
 
-- [OK] L575 INSERT → `tasks`
+- [OK] L577 INSERT → `tasks`
 
-**`PATCH /api/tasks/:id`** — server/index.js:587 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`PATCH /api/tasks/:id`** — server/index.js:589 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
-- L597 _dynamic SQL (`pool.query(variable)`)_
+- L599 _dynamic SQL (`pool.query(variable)`)_
 
-**`DELETE /api/tasks/:id`** — server/index.js:606 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`DELETE /api/tasks/:id`** — server/index.js:608 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
-- [OK] L609 SELECT → `tasks`
--      L616 DELETE → `completions`
-- [OK] L617 DELETE → `tasks`
+- [OK] L611 SELECT → `tasks`
+-      L618 DELETE → `completions`
+- [OK] L619 DELETE → `tasks`
 
-**`POST /api/tasks/:id/reset`** — server/index.js:748 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
+**`POST /api/tasks/:id/reset`** — server/index.js:750 _[requireAuth, requireHouse, requireRole('owner', 'admin')]_
 
-- [OK] L751 UPDATE → `tasks`
+- [OK] L753 UPDATE → `tasks`
 
 ### /api/uploads
 
-**`POST /api/uploads`** — server/index.js:515 _[requireAuth, upload.single('image')]_
+**`POST /api/uploads`** — server/index.js:516 _[requireAuth, upload.single('image')]_
 
 - _Sin queries directas._
 
-**`DELETE /api/uploads/:filename`** — server/index.js:520 _[requireAuth]_
+**`DELETE /api/uploads/:filename`** — server/index.js:521 _[requireAuth]_
 
 - _Sin queries directas._
 
 ### /api/visits
 
-**`GET /api/visits/active`** — server/index.js:706 _[requireAuth, requireHouse]_
+**`GET /api/visits/active`** — server/index.js:708 _[requireAuth, requireHouse]_
 
-- [OK] L708 SELECT → `visits`
+- [OK] L710 SELECT → `visits`
 
-**`POST /api/visits`** — server/index.js:722 _[requireAuth, requireHouse]_
+**`POST /api/visits`** — server/index.js:724 _[requireAuth, requireHouse]_
 
--      L731 SELECT
-- [OK] L735 INSERT → `visits`
+-      L733 SELECT
+- [OK] L737 INSERT → `visits`
 
 ## Helpers / factories con queries
 
-**`sendPushToHouse`** — server/index.js:1358
+**`sendPushToHouse`** — server/index.js:1360
 
-- L1362 SELECT → `push_subscriptions` (filtra org)
-- L1376 DELETE → `push_subscriptions`
+- L1364 SELECT → `push_subscriptions` (filtra org)
+- L1378 DELETE → `push_subscriptions`
 
-**`migrate`** — server/index.js:1388
+**`migrate`** — server/index.js:1390
 
-- L1391 CREATE (filtra org)
-- L1406 CREATE
-- L1415 CREATE
-- L1416 CREATE
-- L1418 CREATE (filtra org)
-- L1430 CREATE
-- L1431 CREATE
-- L1433 CREATE (filtra org)
-- L1443 CREATE (filtra org)
+- L1393 CREATE (filtra org)
+- L1408 CREATE
+- L1417 CREATE
+- L1418 CREATE
+- L1420 CREATE (filtra org)
+- L1432 CREATE
+- L1433 CREATE
+- L1435 CREATE (filtra org)
 - L1445 CREATE (filtra org)
-- L1457 CREATE
-- L1458 CREATE
-- L1480 CREATE (filtra org)
-- L1481 CREATE (filtra org)
+- L1447 CREATE (filtra org)
+- L1459 CREATE
+- L1460 CREATE
 - L1482 CREATE (filtra org)
-- L1486 CREATE
-- L1497 CREATE
-- L1498 CREATE
-- L1501 CREATE (filtra org)
-- L1515 CREATE (filtra org)
-- L1524 CREATE (filtra org)
-- L1527 CREATE
-- L1536 CREATE (filtra org)
-- L1547 CREATE (filtra org)
-- L1549 CREATE
-- L1558 CREATE
-- L1559 CREATE
-- L1562 CREATE (filtra org)
-- L1574 CREATE (filtra org)
-- L1575 CREATE
+- L1483 CREATE (filtra org)
+- L1484 CREATE (filtra org)
+- L1488 CREATE
+- L1499 CREATE
+- L1500 CREATE
+- L1503 CREATE (filtra org)
+- L1517 CREATE (filtra org)
+- L1526 CREATE (filtra org)
+- L1529 CREATE
+- L1538 CREATE (filtra org)
+- L1549 CREATE (filtra org)
+- L1551 CREATE
+- L1560 CREATE
+- L1561 CREATE
+- L1564 CREATE (filtra org)
+- L1576 CREATE (filtra org)
+- L1577 CREATE
 
-**`addColumnIfMissing`** — server/index.js:1583
+**`addColumnIfMissing`** — server/index.js:1585
 
-- L1584 SELECT
-- L1589 ALTER
+- L1586 SELECT
+- L1591 ALTER
 
-**`requireHouse`** — server/lib/middleware.js:42
+**`requireHouse`** — server/lib/middleware.js:54
 
-- L47 SELECT → `member, house_member_profiles` (filtra org)
+- L59 SELECT → `member, house_member_profiles` (filtra org)
 
-**`requireSuperAdmin`** — server/lib/middleware.js:70
+**`requireSuperAdmin`** — server/lib/middleware.js:82
 
-- L72 SELECT → `super_admins`
+- L84 SELECT → `super_admins`
 
 ## Tablas → Endpoints
 
@@ -369,62 +369,62 @@ Queries que tocan tablas con `organization_id` pero no lo filtran:
 - **FK:** `task_id` → `tasks.id`
 - **Multi-tenant:** no
 - **Lectores (9):**
-    - `GET /api/super-admin/stats` (server/index.js:108, SELECT) [sin filtro org]
     - `GET /api/super-admin/stats` (server/index.js:109, SELECT) [sin filtro org]
-    - `GET /api/super-admin/stats` (server/index.js:116, SELECT)
-    - `GET /api/tasks/pending` (server/index.js:534, SELECT)
-    - `GET /api/completions` (server/index.js:629, SELECT)
-    - `GET /api/completions/:taskId/history` (server/index.js:766, SELECT)
-    - `GET /api/stats/participation` (server/index.js:1226, SELECT)
-    - `GET /api/stats/participation` (server/index.js:1246, SELECT)
-    - `GET /api/stats/participation` (server/index.js:1259, SELECT)
+    - `GET /api/super-admin/stats` (server/index.js:110, SELECT) [sin filtro org]
+    - `GET /api/super-admin/stats` (server/index.js:117, SELECT)
+    - `GET /api/tasks/pending` (server/index.js:535, SELECT)
+    - `GET /api/completions` (server/index.js:631, SELECT)
+    - `GET /api/completions/:taskId/history` (server/index.js:768, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1228, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1248, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1261, SELECT)
 - **Escritores (2):**
-    - `DELETE /api/tasks/:id` (server/index.js:616, DELETE) [sin filtro org]
-    - `POST /api/completions` (server/index.js:673, INSERT) [sin filtro org]
+    - `DELETE /api/tasks/:id` (server/index.js:618, DELETE) [sin filtro org]
+    - `POST /api/completions` (server/index.js:675, INSERT) [sin filtro org]
 
 ### `house_member_profiles`
 
 - **Columnas:** `id` UUID, `user_id` TEXT, `organization_id` TEXT, `avatar` TEXT, `color` TEXT, `home_screen` TEXT, `member_type` TEXT, `created_at` TIMESTAMPTZ
 - **Multi-tenant:** si (organization_id)
 - **Lectores (5):**
-    - `GET /api/houses/members` (server/index.js:160, SELECT)
-    - `GET /api/houses/profile` (server/index.js:212, SELECT)
-    - `PUT /api/houses/profile` (server/index.js:235, SELECT)
-    - `GET /api/stats/participation` (server/index.js:1226, SELECT)
-    - helper `requireHouse` (server/lib/middleware.js:47, SELECT)
+    - `GET /api/houses/members` (server/index.js:161, SELECT)
+    - `GET /api/houses/profile` (server/index.js:213, SELECT)
+    - `PUT /api/houses/profile` (server/index.js:236, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1228, SELECT)
+    - helper `requireHouse` (server/lib/middleware.js:59, SELECT)
 - **Escritores (3):**
-    - `PATCH /api/houses/members/:userId/type` (server/index.js:195, INSERT)
-    - `PUT /api/houses/profile` (server/index.js:243, INSERT)
-    - `DELETE /api/houses/:id` (server/index.js:333, DELETE)
+    - `PATCH /api/houses/members/:userId/type` (server/index.js:196, INSERT)
+    - `PUT /api/houses/profile` (server/index.js:244, INSERT)
+    - `DELETE /api/houses/:id` (server/index.js:334, DELETE)
 
 ### `invitation` _(externa — better-auth u otra fuente)_
 
 - **Lectores (1):**
-    - `GET /api/invitations` (server/index.js:259, SELECT)
+    - `GET /api/invitations` (server/index.js:260, SELECT)
 - **Escritores (3):**
-    - `DELETE /api/invitations/:id` (server/index.js:276, DELETE)
-    - `POST /api/invitations/:id/renew` (server/index.js:292, UPDATE)
-    - `DELETE /api/houses/:id` (server/index.js:341, DELETE)
+    - `DELETE /api/invitations/:id` (server/index.js:277, DELETE)
+    - `POST /api/invitations/:id/renew` (server/index.js:293, UPDATE)
+    - `DELETE /api/houses/:id` (server/index.js:342, DELETE)
 
 ### `member` _(externa — better-auth u otra fuente)_
 
 - **Lectores (6):**
-    - `GET /api/super-admin/stats` (server/index.js:106, SELECT) [sin filtro org]
-    - `GET /api/super-admin/stats` (server/index.js:116, SELECT)
-    - `GET /api/houses/members` (server/index.js:160, SELECT)
-    - `PATCH /api/houses/members/:userId/type` (server/index.js:188, SELECT)
-    - `DELETE /api/houses/:id` (server/index.js:316, SELECT)
-    - helper `requireHouse` (server/lib/middleware.js:47, SELECT)
+    - `GET /api/super-admin/stats` (server/index.js:107, SELECT) [sin filtro org]
+    - `GET /api/super-admin/stats` (server/index.js:117, SELECT)
+    - `GET /api/houses/members` (server/index.js:161, SELECT)
+    - `PATCH /api/houses/members/:userId/type` (server/index.js:189, SELECT)
+    - `DELETE /api/houses/:id` (server/index.js:317, SELECT)
+    - helper `requireHouse` (server/lib/middleware.js:59, SELECT)
 - **Escritores (1):**
-    - `DELETE /api/houses/:id` (server/index.js:342, DELETE)
+    - `DELETE /api/houses/:id` (server/index.js:343, DELETE)
 
 ### `organization` _(externa — better-auth u otra fuente)_
 
 - **Lectores (2):**
-    - `GET /api/super-admin/stats` (server/index.js:105, SELECT) [sin filtro org]
-    - `GET /api/super-admin/stats` (server/index.js:116, SELECT)
+    - `GET /api/super-admin/stats` (server/index.js:106, SELECT) [sin filtro org]
+    - `GET /api/super-admin/stats` (server/index.js:117, SELECT)
 - **Escritores (1):**
-    - `DELETE /api/houses/:id` (server/index.js:343, DELETE) [sin filtro org]
+    - `DELETE /api/houses/:id` (server/index.js:344, DELETE) [sin filtro org]
 
 ### `plant_watering_history`
 
@@ -432,65 +432,65 @@ Queries que tocan tablas con `organization_id` pero no lo filtran:
 - **FK:** `plant_id` → `plants.id`
 - **Multi-tenant:** no
 - **Lectores (1):**
-    - `GET /api/plants/:id/history` (server/index.js:1200, SELECT)
+    - `GET /api/plants/:id/history` (server/index.js:1202, SELECT)
 - **Escritores (2):**
-    - `DELETE /api/houses/:id` (server/index.js:335, DELETE)
-    - `POST /api/plants/:id/water` (server/index.js:1171, INSERT) [sin filtro org]
+    - `DELETE /api/houses/:id` (server/index.js:336, DELETE)
+    - `POST /api/plants/:id/water` (server/index.js:1173, INSERT) [sin filtro org]
 
 ### `plants`
 
 - **Columnas:** `id` UUID, `name` TEXT, `notes` TEXT, `watering_frequency_days` INTEGER, `last_watered_at` TIMESTAMPTZ, `organization_id` TEXT, `created_at` TIMESTAMPTZ
 - **Multi-tenant:** si (organization_id)
 - **Lectores (3):**
-    - `GET /api/plants` (server/index.js:1097, SELECT)
-    - `POST /api/plants/:id/water` (server/index.js:1164, SELECT)
-    - `GET /api/plants/:id/history` (server/index.js:1200, SELECT)
+    - `GET /api/plants` (server/index.js:1099, SELECT)
+    - `POST /api/plants/:id/water` (server/index.js:1166, SELECT)
+    - `GET /api/plants/:id/history` (server/index.js:1202, SELECT)
 - **Escritores (6):**
-    - `DELETE /api/houses/:id` (server/index.js:335, DELETE)
-    - `DELETE /api/houses/:id` (server/index.js:339, DELETE)
-    - `POST /api/plants` (server/index.js:1113, INSERT)
-    - `PATCH /api/plants/:id` (server/index.js:1132, UPDATE)
-    - `DELETE /api/plants/:id` (server/index.js:1148, DELETE)
-    - `POST /api/plants/:id/water` (server/index.js:1175, UPDATE)
+    - `DELETE /api/houses/:id` (server/index.js:336, DELETE)
+    - `DELETE /api/houses/:id` (server/index.js:340, DELETE)
+    - `POST /api/plants` (server/index.js:1115, INSERT)
+    - `PATCH /api/plants/:id` (server/index.js:1134, UPDATE)
+    - `DELETE /api/plants/:id` (server/index.js:1150, DELETE)
+    - `POST /api/plants/:id/water` (server/index.js:1177, UPDATE)
 
 ### `products`
 
 - **Columnas:** `id` UUID, `name` TEXT, `category` TEXT, `is_out_of_stock` BOOLEAN, `reminder_frequency_days` INTEGER, `units` INTEGER, `last_purchased_at` TIMESTAMPTZ, `last_out_of_stock_at` TIMESTAMPTZ, `organization_id` TEXT, `created_at` TIMESTAMPTZ
 - **Multi-tenant:** si (organization_id)
 - **Escritores (5):**
-    - `DELETE /api/houses/:id` (server/index.js:330, DELETE)
-    - `POST /api/houses/seed` (server/index.js:491, INSERT)
-    - `POST /api/products` (server/index.js:809, INSERT)
-    - `POST /api/products/:id/purchase` (server/index.js:849, UPDATE)
-    - `DELETE /api/products/:id` (server/index.js:866, DELETE)
+    - `DELETE /api/houses/:id` (server/index.js:331, DELETE)
+    - `POST /api/houses/seed` (server/index.js:492, INSERT)
+    - `POST /api/products` (server/index.js:811, INSERT)
+    - `POST /api/products/:id/purchase` (server/index.js:851, UPDATE)
+    - `DELETE /api/products/:id` (server/index.js:868, DELETE)
 
 ### `push_subscriptions`
 
 - **Columnas:** `id` UUID, `user_id` TEXT, `organization_id` TEXT, `endpoint` TEXT, `keys_p256dh` TEXT, `keys_auth` TEXT, `created_at` TIMESTAMPTZ, `updated_at` TIMESTAMPTZ
 - **Multi-tenant:** si (organization_id)
 - **Lectores (2):**
-    - `GET /api/push/status` (server/index.js:1347, SELECT)
-    - helper `sendPushToHouse` (server/index.js:1362, SELECT)
+    - `GET /api/push/status` (server/index.js:1349, SELECT)
+    - helper `sendPushToHouse` (server/index.js:1364, SELECT)
 - **Escritores (4):**
-    - `DELETE /api/houses/:id` (server/index.js:334, DELETE)
-    - `POST /api/push/subscribe` (server/index.js:1315, INSERT)
-    - `DELETE /api/push/subscribe` (server/index.js:1337, DELETE) [sin filtro org]
-    - helper `sendPushToHouse` (server/index.js:1376, DELETE) [sin filtro org]
+    - `DELETE /api/houses/:id` (server/index.js:335, DELETE)
+    - `POST /api/push/subscribe` (server/index.js:1317, INSERT)
+    - `DELETE /api/push/subscribe` (server/index.js:1339, DELETE) [sin filtro org]
+    - helper `sendPushToHouse` (server/index.js:1378, DELETE) [sin filtro org]
 
 ### `shopping_categories`
 
 - **Columnas:** `id` UUID, `name` TEXT, `emoji` TEXT, `sort_order` INTEGER, `organization_id` TEXT, `created_at` TIMESTAMPTZ
 - **Multi-tenant:** si (organization_id)
 - **Lectores (5):**
-    - `GET /api/shopping-categories` (server/index.js:878, SELECT)
-    - `POST /api/shopping-categories` (server/index.js:894, SELECT)
-    - `GET /api/shopping-items` (server/index.js:955, SELECT)
-    - `GET /api/shopping-items/history` (server/index.js:1039, SELECT)
-    - `GET /api/shopping-items/recommendations` (server/index.js:1057, SELECT)
+    - `GET /api/shopping-categories` (server/index.js:880, SELECT)
+    - `POST /api/shopping-categories` (server/index.js:896, SELECT)
+    - `GET /api/shopping-items` (server/index.js:957, SELECT)
+    - `GET /api/shopping-items/history` (server/index.js:1041, SELECT)
+    - `GET /api/shopping-items/recommendations` (server/index.js:1059, SELECT)
 - **Escritores (3):**
-    - `DELETE /api/houses/:id` (server/index.js:332, DELETE)
-    - `POST /api/shopping-categories` (server/index.js:898, INSERT)
-    - `DELETE /api/shopping-categories/:id` (server/index.js:931, DELETE)
+    - `DELETE /api/houses/:id` (server/index.js:333, DELETE)
+    - `POST /api/shopping-categories` (server/index.js:900, INSERT)
+    - `DELETE /api/shopping-categories/:id` (server/index.js:933, DELETE)
 
 ### `shopping_items`
 
@@ -498,64 +498,64 @@ Queries que tocan tablas con `organization_id` pero no lo filtran:
 - **FK:** `category_id` → `shopping_categories.id`
 - **Multi-tenant:** si (organization_id)
 - **Lectores (4):**
-    - `GET /api/shopping-items` (server/index.js:955, SELECT)
-    - `GET /api/shopping-items/history` (server/index.js:1039, SELECT)
-    - `GET /api/shopping-items/recommendations` (server/index.js:1057, SELECT)
-    - `GET /api/shopping-items/recommendations` (server/index.js:1068, SELECT)
+    - `GET /api/shopping-items` (server/index.js:957, SELECT)
+    - `GET /api/shopping-items/history` (server/index.js:1041, SELECT)
+    - `GET /api/shopping-items/recommendations` (server/index.js:1059, SELECT)
+    - `GET /api/shopping-items/recommendations` (server/index.js:1070, SELECT)
 - **Escritores (5):**
-    - `DELETE /api/houses/:id` (server/index.js:331, DELETE)
-    - `GET /api/shopping-items` (server/index.js:944, UPDATE)
-    - `POST /api/shopping-items` (server/index.js:973, INSERT)
-    - `DELETE /api/shopping-items/clear-purchased` (server/index.js:1019, UPDATE)
-    - `DELETE /api/shopping-items/:id` (server/index.js:1085, DELETE)
+    - `DELETE /api/houses/:id` (server/index.js:332, DELETE)
+    - `GET /api/shopping-items` (server/index.js:946, UPDATE)
+    - `POST /api/shopping-items` (server/index.js:975, INSERT)
+    - `DELETE /api/shopping-items/clear-purchased` (server/index.js:1021, UPDATE)
+    - `DELETE /api/shopping-items/:id` (server/index.js:1087, DELETE)
 
 ### `super_admins`
 
 - **Columnas:** `id` UUID, `user_id` TEXT, `created_at` TIMESTAMPTZ
 - **Multi-tenant:** no
 - **Lectores (2):**
-    - `GET /api/super-admin/check` (server/index.js:90, SELECT) [sin filtro org]
-    - helper `requireSuperAdmin` (server/lib/middleware.js:72, SELECT) [sin filtro org]
+    - `GET /api/super-admin/check` (server/index.js:91, SELECT) [sin filtro org]
+    - helper `requireSuperAdmin` (server/lib/middleware.js:84, SELECT) [sin filtro org]
 
 ### `tasks`
 
 - **Columnas:** `id` UUID, `name` TEXT, `description` TEXT, `frequency_type` TEXT, `frequency_value` INTEGER, `is_active` BOOLEAN, `product_name` TEXT, `product_image` TEXT, `organization_id` TEXT, `last_reset_at` TIMESTAMPTZ, `created_at` TIMESTAMPTZ
 - **Multi-tenant:** si (organization_id)
 - **Lectores (11):**
-    - `GET /api/super-admin/stats` (server/index.js:107, SELECT) [sin filtro org]
-    - `GET /api/super-admin/stats` (server/index.js:116, SELECT)
-    - `POST /api/houses/seed` (server/index.js:363, SELECT)
-    - `GET /api/tasks/pending` (server/index.js:534, SELECT)
-    - `DELETE /api/tasks/:id` (server/index.js:609, SELECT)
-    - `GET /api/completions` (server/index.js:629, SELECT)
-    - `POST /api/completions` (server/index.js:647, SELECT)
-    - `GET /api/completions/:taskId/history` (server/index.js:766, SELECT)
-    - `GET /api/stats/participation` (server/index.js:1226, SELECT)
-    - `GET /api/stats/participation` (server/index.js:1246, SELECT)
-    - `GET /api/stats/participation` (server/index.js:1259, SELECT)
+    - `GET /api/super-admin/stats` (server/index.js:108, SELECT) [sin filtro org]
+    - `GET /api/super-admin/stats` (server/index.js:117, SELECT)
+    - `POST /api/houses/seed` (server/index.js:364, SELECT)
+    - `GET /api/tasks/pending` (server/index.js:535, SELECT)
+    - `DELETE /api/tasks/:id` (server/index.js:611, SELECT)
+    - `GET /api/completions` (server/index.js:631, SELECT)
+    - `POST /api/completions` (server/index.js:649, SELECT)
+    - `GET /api/completions/:taskId/history` (server/index.js:768, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1228, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1248, SELECT)
+    - `GET /api/stats/participation` (server/index.js:1261, SELECT)
 - **Escritores (7):**
-    - `DELETE /api/houses/:id` (server/index.js:329, DELETE)
-    - `POST /api/houses/seed` (server/index.js:399, INSERT)
-    - `POST /api/houses/seed` (server/index.js:435, INSERT)
-    - `POST /api/tasks` (server/index.js:575, INSERT)
-    - `DELETE /api/tasks/:id` (server/index.js:617, DELETE)
-    - `POST /api/completions` (server/index.js:680, UPDATE)
-    - `POST /api/tasks/:id/reset` (server/index.js:751, UPDATE)
+    - `DELETE /api/houses/:id` (server/index.js:330, DELETE)
+    - `POST /api/houses/seed` (server/index.js:400, INSERT)
+    - `POST /api/houses/seed` (server/index.js:436, INSERT)
+    - `POST /api/tasks` (server/index.js:577, INSERT)
+    - `DELETE /api/tasks/:id` (server/index.js:619, DELETE)
+    - `POST /api/completions` (server/index.js:682, UPDATE)
+    - `POST /api/tasks/:id/reset` (server/index.js:753, UPDATE)
 
 ### `user` _(externa — better-auth u otra fuente)_
 
 - **Lectores (3):**
-    - `GET /api/super-admin/stats` (server/index.js:104, SELECT) [sin filtro org]
-    - `GET /api/houses/members` (server/index.js:160, SELECT)
-    - `GET /api/invitations` (server/index.js:259, SELECT)
+    - `GET /api/super-admin/stats` (server/index.js:105, SELECT) [sin filtro org]
+    - `GET /api/houses/members` (server/index.js:161, SELECT)
+    - `GET /api/invitations` (server/index.js:260, SELECT)
 
 ### `visits`
 
 - **Columnas:** `id` UUID, `organization_id` TEXT, `user_id` TEXT, `visited_on` DATE, `created_at` TIMESTAMPTZ
 - **Multi-tenant:** si (organization_id)
 - **Lectores (2):**
-    - `POST /api/completions` (server/index.js:656, SELECT)
-    - `GET /api/visits/active` (server/index.js:708, SELECT)
+    - `POST /api/completions` (server/index.js:658, SELECT)
+    - `GET /api/visits/active` (server/index.js:710, SELECT)
 - **Escritores (1):**
-    - `POST /api/visits` (server/index.js:735, INSERT)
+    - `POST /api/visits` (server/index.js:737, INSERT)
 

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -5,6 +5,7 @@ import {
   frequencyLabel, FREQUENCY_LABELS,
 } from '../lib/tasks'
 import { getImageUrl, fetchHouseMembers } from '../lib/api'
+import { authClient } from '../lib/auth'
 import TaskForm from '../components/TaskForm'
 import HistoryModal from '../components/HistoryModal'
 
@@ -47,10 +48,16 @@ export default function Admin() {
   const [historyTask, setHistoryTask] = useState(null)
   const [toast, setToast] = useState(null)
   const [members, setMembers] = useState([])
+  const { data: session } = authClient.useSession()
 
   useEffect(() => {
     fetchHouseMembers().then(setMembers).catch(() => {})
   }, [])
+
+  // Todo miembro puede crear tareas; editarlas, borrarlas o resetearlas sigue
+  // reservado a duenos y admins (mismo criterio que la API).
+  const myRole = members.find(m => m.userId === session?.user?.id)?.role
+  const canManage = myRole === 'owner' || myRole === 'admin'
 
   const showToast = (msg, type = 'success') => {
     setToast({ msg, type })
@@ -247,6 +254,7 @@ export default function Admin() {
               task={task}
               deletingId={deletingId}
               resettingId={resettingId}
+              canManage={canManage}
               onEdit={openEdit}
               onDelete={handleDelete}
               onReset={handleReset}
@@ -289,7 +297,7 @@ export default function Admin() {
   )
 }
 
-function TaskAdminCard({ task, deletingId, resettingId, onEdit, onDelete, onReset, onToggleActive, onHistory }) {
+function TaskAdminCard({ task, canManage, deletingId, resettingId, onEdit, onDelete, onReset, onToggleActive, onHistory }) {
   const isDeleting = deletingId === task.id
   const isResetting = resettingId === task.id
 
@@ -316,8 +324,10 @@ function TaskAdminCard({ task, deletingId, resettingId, onEdit, onDelete, onRese
         <div className="flex items-start gap-2.5">
           {/* Toggle */}
           <button
-            onClick={() => onToggleActive(task)}
-            className="mt-0.5 flex-shrink-0 w-[18px] h-[18px] rounded-md border-[1.5px] flex items-center justify-center transition-all"
+            onClick={() => canManage && onToggleActive(task)}
+            disabled={!canManage}
+            aria-label={task.is_active ? 'Tarea activa' : 'Tarea inactiva'}
+            className="mt-0.5 flex-shrink-0 w-[18px] h-[18px] rounded-md border-[1.5px] flex items-center justify-center transition-all disabled:cursor-default"
             style={{
               background: task.is_active ? 'var(--moss-400)' : 'transparent',
               borderColor: task.is_active ? 'var(--moss-400)' : 'var(--bark-200)',
@@ -389,6 +399,8 @@ function TaskAdminCard({ task, deletingId, resettingId, onEdit, onDelete, onRese
             <circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/>
           </svg>
         </AdminBtn>
+        {canManage && (
+        <>
         <AdminBtn onClick={() => onReset(task)} title="Resetear" disabled={isResetting}>
           {isResetting ? (
             <div className="w-3.5 h-3.5 rounded-full border-[1.5px] border-t-transparent animate-spin" style={{ borderColor: 'var(--moss-200)', borderTopColor: 'transparent' }} />
@@ -418,6 +430,8 @@ function TaskAdminCard({ task, deletingId, resettingId, onEdit, onDelete, onRese
             </svg>
           )}
         </AdminBtn>
+        </>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/pages/__tests__/Admin.test.jsx
+++ b/frontend/src/pages/__tests__/Admin.test.jsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Admin from '../Admin'
+
+vi.mock('../../lib/tasks', async () => {
+  const actual = await vi.importActual('../../lib/tasks')
+  return {
+    ...actual,
+    fetchAllTasks: vi.fn(),
+    createTask: vi.fn(),
+    updateTask: vi.fn(),
+    deleteTask: vi.fn(),
+    resetTask: vi.fn(),
+  }
+})
+
+vi.mock('../../lib/api', () => ({
+  getImageUrl: (name) => `/uploads/${name}`,
+  fetchHouseMembers: vi.fn(),
+}))
+
+vi.mock('../../lib/auth', () => ({
+  authClient: { useSession: vi.fn() },
+}))
+
+import { fetchAllTasks } from '../../lib/tasks'
+import { fetchHouseMembers } from '../../lib/api'
+import { authClient } from '../../lib/auth'
+
+const TASK = {
+  id: 't1',
+  name: 'Trapear la cocina',
+  description: null,
+  frequency_type: 'weekly',
+  frequency_value: 7,
+  is_active: true,
+  product_name: null,
+  product_image: null,
+  organization_id: 'org-1',
+}
+
+function renderAdmin() {
+  return render(
+    <MemoryRouter>
+      <Admin />
+    </MemoryRouter>
+  )
+}
+
+function mockSessionAs(role) {
+  authClient.useSession.mockReturnValue({ data: { user: { id: 'u1' } } })
+  fetchHouseMembers.mockResolvedValue([
+    { userId: 'u1', name: 'Juan', avatar: '🧑', color: '#6a9960', role },
+  ])
+}
+
+describe('Admin page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    fetchAllTasks.mockResolvedValue([TASK])
+  })
+
+  it('un miembro puede crear tareas', async () => {
+    mockSessionAs('member')
+    renderAdmin()
+
+    await waitFor(() => expect(screen.getByText('Trapear la cocina')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: /Nueva/ })).toBeInTheDocument()
+  })
+
+  it('un miembro no ve editar, eliminar ni resetear', async () => {
+    mockSessionAs('member')
+    renderAdmin()
+
+    await waitFor(() => expect(screen.getByText('Trapear la cocina')).toBeInTheDocument())
+    expect(screen.queryByTitle('Editar')).not.toBeInTheDocument()
+    expect(screen.queryByTitle('Eliminar')).not.toBeInTheDocument()
+    expect(screen.queryByTitle('Resetear')).not.toBeInTheDocument()
+    // El historial sigue disponible para cualquier miembro.
+    expect(screen.getByTitle('Historial')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Tarea activa' })).toBeDisabled()
+  })
+
+  it('un admin conserva todas las acciones de gestion', async () => {
+    mockSessionAs('admin')
+    renderAdmin()
+
+    await waitFor(() => expect(screen.getByTitle('Editar')).toBeInTheDocument())
+    expect(screen.getByTitle('Eliminar')).toBeInTheDocument()
+    expect(screen.getByTitle('Resetear')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Tarea activa' })).toBeEnabled()
+  })
+})

--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,7 @@ import { createAuth } from './auth.js'
 import webpush from 'web-push'
 import {
   requireRole,
+  denyExternalMembers,
   createRequireAuth,
   createRequireHouse,
   createRequireSuperAdmin,
@@ -569,7 +570,8 @@ app.get('/api/tasks', requireAuth, requireHouse, async (req, res) => {
 })
 
 // POST /api/tasks
-app.post('/api/tasks', requireAuth, requireHouse, requireRole('owner', 'admin'), async (req, res) => {
+// Cualquier miembro de la casa puede crear tareas (el personal externo no).
+app.post('/api/tasks', requireAuth, requireHouse, denyExternalMembers, async (req, res) => {
   try {
     const { name, description, frequency_type, frequency_value, is_active, product_name, product_image } = req.body
     const { rows } = await pool.query(

--- a/server/lib/middleware.js
+++ b/server/lib/middleware.js
@@ -17,6 +17,18 @@ export function requireRole(...roles) {
 }
 
 /**
+ * denyExternalMembers - bloquea al personal externo en acciones de gestion.
+ * El rol externo solo marca visitas y completa tareas; no administra la casa.
+ * Requiere req.house (normalmente por requireHouse).
+ */
+export function denyExternalMembers(req, res, next) {
+  if (!req.house || req.house.memberType === 'externo') {
+    return res.status(403).json({ error: 'No tienes permisos para esta accion' })
+  }
+  next()
+}
+
+/**
  * createRequireAuth - factory que recibe la instancia de better-auth
  * y devuelve un middleware que resuelve la sesion a partir de los headers.
  */

--- a/server/lib/middleware.test.js
+++ b/server/lib/middleware.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import {
   requireRole,
+  denyExternalMembers,
   createRequireAuth,
   createRequireHouse,
   createRequireSuperAdmin,
@@ -62,6 +63,54 @@ describe('requireRole', () => {
     mw(req, res, next)
 
     expect(next).toHaveBeenCalledOnce()
+  })
+})
+
+describe('denyExternalMembers', () => {
+  it('llama next() para un miembro regular', () => {
+    const req = { house: { role: 'member', memberType: 'regular' } }
+    const res = mockRes()
+    const next = vi.fn()
+
+    denyExternalMembers(req, res, next)
+
+    expect(next).toHaveBeenCalledOnce()
+    expect(res.status).not.toHaveBeenCalled()
+  })
+
+  it('llama next() para owner y admin', () => {
+    for (const role of ['owner', 'admin']) {
+      const req = { house: { role, memberType: 'regular' } }
+      const res = mockRes()
+      const next = vi.fn()
+
+      denyExternalMembers(req, res, next)
+
+      expect(next).toHaveBeenCalledOnce()
+    }
+  })
+
+  it('responde 403 cuando el miembro es externo', () => {
+    const req = { house: { role: 'member', memberType: 'externo' } }
+    const res = mockRes()
+    const next = vi.fn()
+
+    denyExternalMembers(req, res, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(403)
+    expect(res.json).toHaveBeenCalledWith({ error: 'No tienes permisos para esta accion' })
+  })
+
+  it('responde 403 cuando req.house no esta definido', () => {
+    const req = {}
+    const res = mockRes()
+    const next = vi.fn()
+
+    denyExternalMembers(req, res, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(403)
   })
 })
 


### PR DESCRIPTION
POST /api/tasks pasa de requireRole('owner','admin') a un nuevo
middleware denyExternalMembers: entra cualquier miembro (owner, admin
o member) salvo el personal externo, que sigue limitado a marcar
llegada y completar tareas. Editar, borrar y resetear no cambian.

En Admin.jsx se deriva el rol propio de fetchHouseMembers() + la
sesion para exponer canManage: el miembro regular conserva "Nueva" y
el historial, y se ocultan las acciones que antes solo devolvian 403.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Umj7aj2PcB9cw4Xe3rKMqS